### PR TITLE
feat: 공통 응답 및 도메인 별 에러코드 구현

### DIFF
--- a/src/main/java/com/sparta/delivhub/common/dto/ApiResponse.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.sparta.delivhub.common.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+    
+    private int status;
+    private String message;
+    private T data;
+
+    // 성공 응답 (데이터가 있는 경우)
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(200, "SUCCESS", data);
+    }
+
+    // 성공 응답 (데이터가 없는 경우, 예: 삭제 완료)
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>(200, "SUCCESS", null);
+    }
+}

--- a/src/main/java/com/sparta/delivhub/common/dto/BusinessException.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/BusinessException.java
@@ -1,0 +1,13 @@
+package com.sparta.delivhub.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
@@ -1,0 +1,149 @@
+package com.sparta.delivhub.common.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    
+    // 1. Common (공통 검증 및 서버 에러)
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "C001", "잘못된 요청입니다."),
+    INVALID_INPUT_DATA(HttpStatus.BAD_REQUEST, "C002", "입력 데이터가 올바르지 않습니다."),
+    REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "C003", "필수 입력값이 누락되었습니다."),
+    NO_CHANGES_DETECTED(HttpStatus.BAD_REQUEST, "C004", "변경할 내용이 없습니다."),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류가 발생했습니다."),
+
+    // 2. User (회원 및 검증 로직)
+    INVALID_USERNAME(HttpStatus.BAD_REQUEST, "U001", "유효하지 않은 사용자 이름입니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "U002", "이메일 형식이 올바르지 않습니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "U003", "비밀번호 형식이 올바르지 않습니다."),
+    PASSWORD_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "U004", "새 비밀번호가 현재 비밀번호와 동일합니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "U005", "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "U006", "이미 사용 중인 닉네임입니다."),
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "U007", "유효하지 않은 권한(Role) 값입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U008", "사용자를 찾을 수 없습니다."),
+    ALREADY_DELETED_USER(HttpStatus.NOT_FOUND, "U009", "이미 탈퇴 처리된 사용자입니다."),
+
+    // 3. Auth & Permission (인증 및 인가)
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),
+    WRONG_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "A003", "현재 비밀번호가 일치하지 않습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A004", "해당 작업을 수행할 권한이 없습니다."),
+    MASTER_ONLY(HttpStatus.FORBIDDEN, "A005", "MASTER 권한만 접근할 수 있습니다."),
+    CANNOT_CHANGE_OWN_ROLE(HttpStatus.FORBIDDEN, "A006", "자신의 권한은 스스로 변경할 수 없습니다."),
+
+    // 4. Address (주소 로직)
+    INVALID_ADDRESSID(HttpStatus.BAD_REQUEST, "AD001", "유효하지 않은 주소 ID입니다."),
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "AD002", "해당 주소를 찾을 수 없습니다."),
+    ALREADY_DELETED_ADDRESS(HttpStatus.NOT_FOUND, "AD003", "이미 삭제된 주소입니다."),
+
+    // 5. Store (가게 로직)
+    INVALID_STORE_ID(HttpStatus.BAD_REQUEST, "S001", "유효하지 않은 가게 ID(UUID) 형식입니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "S002", "페이징 값 또는 파라미터가 올바르지 않습니다."),
+    ALREADY_HIDDEN(HttpStatus.BAD_REQUEST, "S003", "이미 숨김 처리된 가게입니다."),
+    NOT_STORE_OWNER(HttpStatus.FORBIDDEN, "S004", "본인의 가게만 수정 또는 관리할 수 있습니다."),
+    FORBIDDEN_STORE_ACTION(HttpStatus.FORBIDDEN, "S005", "해당 가게에 대한 관리 권한이 없습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S006", "존재하지 않거나 삭제된 가게입니다."),
+
+    // 6. Category (카테고리 로직)
+    CATEGORY_INVALID_INPUT(HttpStatus.BAD_REQUEST, "CT001", "카테고리 이름이 누락되었거나 너무 길 때 발생합니다."),
+    CATEGORY_INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "CT002", "페이징 파라미터가 잘못되었을 때 발생합니다."),
+    INVALID_CATEGORY_ID(HttpStatus.BAD_REQUEST, "CT003", "UUID 형식이 아닌 잘못된 값이 들어왔을 때 발생합니다."),
+    CATEGORY_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "CT004", "로그인 세션이 만료되었거나 인증 정보가 없을 때 발생합니다."),
+    CATEGORY_FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "CT005", "OWNER나 CUSTOMER 권한으로 생성을 시도하거나, 관리자(MANAGER, MASTER)가 아닌 권한으로 수정을 시도할 때 발생합니다."),
+    CATEGORY_FORBIDDEN_DELETE(HttpStatus.FORBIDDEN, "CT006", "MASTER가 아닌데 삭제를 시도할 때 발생합니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CT007", "존재하지 않거나 이미 삭제된 categoryId를 조회했거나, 수정하려는 카테고리 ID가 DB에 없을 때 발생합니다."),
+    CATEGORY_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "CT008", "이미 삭제되었거나 존재하지 않는 카테고리일 때 발생합니다."),
+
+    // 7. Area (지역 로직)
+    INVALID_AREA_INPUT(HttpStatus.BAD_REQUEST, "AR001", "시/도, 군/구, 상세 주소 중 누락된 값이 있거나 형식이 잘못되었을 때."),
+    INVALID_PAGING_PARAMETER(HttpStatus.BAD_REQUEST, "AR002", "page나 size 값이 음수이거나 숫자가 아닐 때."),
+    INVALID_AREA_ID(HttpStatus.BAD_REQUEST, "AR003", "areaId가 유효한 UUID 형식이 아닐 때."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "AR004", "인증되지 않은 사용자가 접근했을 때."),
+    FORBIDDEN_AREA_MANAGEMENT_CREATE(HttpStatus.FORBIDDEN, "AR005", "관리자가 아닌 권한(OWNER, CUSTOMER)으로 지역을 생성하려 할 때."),
+    FORBIDDEN_AREA_MANAGEMENT_UPDATE(HttpStatus.FORBIDDEN, "AR006", "관리자 권한이 없는 유저가 수정을 시도할 때."),
+    FORBIDDEN_AREA_DELETE(HttpStatus.FORBIDDEN, "AR007", "MASTER 권한이 아닌 유저(MANAGER 포함)가 삭제를 시도할 때."),
+    AREA_NOT_FOUND_ON_READ(HttpStatus.NOT_FOUND, "AR008", "존재하지 않거나 소프트 삭제된 areaId를 조회했을 때."),
+    AREA_NOT_FOUND_ON_UPDATE(HttpStatus.NOT_FOUND, "AR009", "수정하려는 지역 ID가 DB에 없을 때."),
+    AREA_NOT_FOUND_ON_DELETE(HttpStatus.NOT_FOUND, "AR010", "이미 삭제되었거나 존재하지 않는 지역을 삭제하려 할 때."),
+
+    // 8. Menu (메뉴 로직)
+    MENU_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 가게입니다."),
+    MENU_FORBIDDEN_ON_READ(HttpStatus.FORBIDDEN, "M002", "숨김 또는 삭제된 메뉴에 접근할 권한이 없습니다."),
+    MENU_NOT_FOUND_ON_READ(HttpStatus.NOT_FOUND, "M003", "존재하지 않는 메뉴입니다."),
+    MENU_FORBIDDEN_ON_UPDATE(HttpStatus.FORBIDDEN, "M004", "본인 가게의 메뉴만 수정할 수 있습니다."),
+    MENU_NOT_FOUND_ON_UPDATE(HttpStatus.NOT_FOUND, "M005", "존재하지 않는 메뉴입니다."),
+    MENU_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "M006", "누락된 값이 있습니다."),
+    MENU_FORBIDDEN_ON_UPDATE_STATUS(HttpStatus.FORBIDDEN, "M007", "본인 가게의 메뉴만 수정할 수 있습니다."),
+    MENU_NOT_FOUND_ON_UPDATE_STATUS(HttpStatus.NOT_FOUND, "M008", "존재하지 않는 메뉴입니다."),
+    MENU_FORBIDDEN_ON_DELETE(HttpStatus.FORBIDDEN, "M009", "본인 가게의 메뉴만 삭제할 수 있습니다."),
+    MENU_NOT_FOUND_ON_DELETE(HttpStatus.NOT_FOUND, "M010", "존재하지 않는 메뉴입니다."),
+
+    // 9. Option (옵션 로직)
+    OPTION_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "OP001", "누락된 값이 있습니다."),
+    OPTION_FORBIDDEN_ON_CREATE(HttpStatus.FORBIDDEN, "OP002", "본인 가게의 메뉴에만 옵션을 등록할 수 있습니다."),
+    MENU_NOT_FOUND_ON_OPTION_CREATE(HttpStatus.NOT_FOUND, "OP003", "존재하지 않는 메뉴입니다."),
+    MENU_NOT_FOUND_ON_OPTION_READ(HttpStatus.NOT_FOUND, "OP004", "존재하지 않는 메뉴입니다."),
+    OPTION_FORBIDDEN_ON_UPDATE(HttpStatus.FORBIDDEN, "OP005", "본인 가게의 메뉴에 속한 옵션만 수정할 수 있습니다."),
+    OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "OP006", "존재하지 않는 옵션입니다."),
+
+    // 10. Order (주문 로직)
+    ORDER_PARAM_MISSING(HttpStatus.BAD_REQUEST, "OD001", "필수 파라미터 누락"),
+    ORDER_INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "OD002", "quantity가 1 미만입니다."),
+    ORDER_RELATION_NOT_FOUND(HttpStatus.NOT_FOUND, "OD003", "존재하지 않는 가게/배송지/메뉴입니다."),
+
+    ORDER_INVALID_SIZE(HttpStatus.BAD_REQUEST, "OD004", "허용되지 않은 size 값입니다."),
+    ORDER_READ_FORBIDDEN(HttpStatus.FORBIDDEN, "OD005", "조회 권한이 없습니다."),
+
+    ORDER_ACCESS_DENIED_ON_READ(HttpStatus.FORBIDDEN, "OD006", "해당 주문에 대한 접근 권한이 없습니다."),
+    ORDER_NOT_FOUND_ON_READ(HttpStatus.NOT_FOUND, "OD007", "존재하지 않는 주문입니다."),
+
+    ORDER_UNMODIFIABLE(HttpStatus.BAD_REQUEST, "OD008", "접수된 주문은 요청사항을 수정할 수 없습니다."),
+    ORDER_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "OD009", "본인 주문만 수정 가능합니다."),
+    ORDER_NOT_FOUND_ON_UPDATE(HttpStatus.NOT_FOUND, "OD010", "존재하지 않는 주문입니다."),
+
+    ORDER_STATUS_REVERSE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "OD011", "역방향으로 상태를 변경할 수 없습니다."),
+    ORDER_STATUS_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "OD012", "상태 변경 권한이 없습니다."),
+
+    ORDER_CANCEL_TIMEOUT(HttpStatus.BAD_REQUEST, "OD013", "주문 생성 후 5분이 경과하여 취소할 수 없습니다."),
+    ORDER_ALREADY_COOKING(HttpStatus.BAD_REQUEST, "OD014", "이미 조리중인 주문은 취소 불가."),
+    ORDER_CANCEL_FORBIDDEN(HttpStatus.FORBIDDEN, "OD015", "권한이 없습니다."),
+
+    ORDER_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "OD016", "관리자(MASTER) 권한이 필요합니다."),
+    ORDER_NOT_FOUND_ON_DELETE(HttpStatus.NOT_FOUND, "OD017", "주문이 존재하지 않습니다."),
+
+    // 11. Payment (결제 로직)
+    PAYMENT_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "P001", "결제 금액은 0원보다 커야 하거나, 지원하지 않는 결제 수단입니다."),
+    PAYMENT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "P002", "이미 삭제 처리된 결제 내역입니다."),
+
+    STORE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P003", "해당 가게의 관리자(MANAGER) 또는 마스터(MASTER) 권한이 필요합니다."),
+    PAYMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "P004", "본인이 작성한 결제 내역만 상태를 변경할 수 있습니다."),
+
+    // 가게 식별자 에러 (기존 STORE_NOT_FOUND가 있지만 요청하신 메시지로 새로 생성)
+    PAYMENT_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "P005", "해당 storeId가 존재하지 않거나, 이미 삭제된 가게입니다."),
+
+    // 12. Review (리뷰 로직)
+    REVIEW_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "R001", "별점은 1점 이상 5점 이하로 입력해주세요."),
+    REVIEW_BAD_REQUEST_STATUS(HttpStatus.BAD_REQUEST, "R002", "주문 상태가 COMPLETED가 아닌데 리뷰를 쓰려고 합니다. 배달 완료 후 작성해주세요."),
+    REVIEW_PAGING_ERROR(HttpStatus.BAD_REQUEST, "R003", "페이지 번호는 0 이상이어야 합니다."),
+
+    REVIEW_SECURITY_EXCEPTION(HttpStatus.FORBIDDEN, "R004", "권한이 없습니다. 로그인 세션이 만료되었는지 확인해주세요."),
+    REVIEW_FORBIDDEN_UPDATE(HttpStatus.FORBIDDEN, "R005", "해당 리뷰를 수정할 권한이 없습니다."),
+    REVIEW_FORBIDDEN_DELETE(HttpStatus.FORBIDDEN, "R006", "해당 리뷰를 수정할 권한이 없습니다."), // 요청하신 메시지 그대로 유지
+
+    REVIEW_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "R007", "해당 가게 정보를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R008", "존재하지 않거나 이미 삭제 처리가 완료된 리뷰입니다."),
+
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "R009", "이미 해당 주문에 대해 작성된 리뷰가 존재합니다."),
+
+    // 13. AI Log (AI 시스템 로직)
+    AI_LOG_FORBIDDEN(HttpStatus.FORBIDDEN, "AI001", "AI 로그 접근은 관리자(MANAGER, MASTER)만 가능합니다."),
+    AI_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "AI002", "존재하지 않는 AI 로그입니다."),
+    AI_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI003", "AI 응답을 받지 못했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/sparta/delivhub/common/dto/ErrorResponse.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.delivhub.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 JSON에서 아예 제외함
+public class ErrorResponse {
+    private int status;
+    private String message;
+    private List<FieldErrorDetail> errors; // 검증 에러가 있을 때만 나감
+
+    @Getter
+    @Builder
+    public static class FieldErrorDetail {
+        private String field;
+        private String message;
+    }
+}

--- a/src/main/java/com/sparta/delivhub/common/dto/PageResponse.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/PageResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.delivhub.common.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+
+    public PageResponse(Page<T> pageInfo) {
+        this.content = pageInfo.getContent();
+        this.page = pageInfo.getNumber();
+        this.size = pageInfo.getSize();
+        this.totalElements = pageInfo.getTotalElements();
+        this.totalPages = pageInfo.getTotalPages();
+    }
+}

--- a/src/main/java/com/sparta/delivhub/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivhub/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.sparta.delivhub.common.handler;
+
+import com.sparta.delivhub.common.dto.ErrorResponse;
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 1. 우리가 만든 비즈니스 예외 처리 (throw new BusinessException(...))
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .message(errorCode.name()) // 예: "STORE_NOT_FOUND"
+                .build();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    // 2. 입력값 검증 실패 시 (@Valid 에러)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        List<ErrorResponse.FieldErrorDetail> fieldErrors = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> ErrorResponse.FieldErrorDetail.builder()
+                        .field(error.getField())
+                        .message(error.getDefaultMessage())
+                        .build())
+                .toList();
+
+        ErrorResponse response = ErrorResponse.builder()
+                .status(400)
+                .message("VALIDATION_ERROR")
+                .errors(fieldErrors)
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    // 3. 그 외 알 수 없는 모든 에러 방어
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(500)
+                .message("SERVER_ERROR")
+                .build();
+        // 실무에서는 여기에 log.error("Server Error: ", e); 를 추가합니다.
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}


### PR DESCRIPTION
## 💡 PR 제목
 feat: [KIM] 공통 응답 및 도메인 별 에러코드 구현


---

## 🔗 관련 이슈

---

## 📌 작업 내용 요약
- [x] GlobalExceptionHandler를 통한 전역 예외 처리 로직 추가

---

## 🧱 변경 범위 (Scope)
### Backend
- [ ] API 추가/수정
- [ ] Validation/예외처리
- [ ] 인증/인가
- [ ] DB 스키마/쿼리
- [x] 기타:

### Frontend
- [ ] UI/라우팅
- [ ] 상태관리/비동기 로직
- [ ] 입력값/검증
- [ ] 기타:

---

## 🧪 테스트 내역
### Backend
- [ ] 로컬에서 애플리케이션 실행 확인
- [ ] 단위 테스트 통과
- [ ] API 수동 테스트 (Postman / Swagger 등)

### Frontend
- [ ] `npm run dev` 로컬 실행 확인
- [ ] 주요 화면/기능 수동 테스트

### 테스트 상세(필수)
> 테스트한 API/페이지/케이스를 간단히 적어주세요.
- 예) 로그인 성공/실패, 회원가입, 목록 조회 등

---

## 🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
- before:
- after:

---

## ⚠️ 영향도 / 리스크 / 롤백
> 리뷰어가 “머지해도 되는지” 판단하기 위한 섹션입니다.
- 영향도: (예: 기존 API 응답 변경 없음 / 있음)
- 리스크: (예: 권한 로직 수정, 쿼리 성능, 마이그레이션 필요 등)
- 롤백 방법: (예: revert 커밋 / 기능 플래그 off / 마이그레이션 롤백 불가 등)

---

## ✅ 리뷰어 체크 포인트 (선택)
> 리뷰어가 집중해서 봐줬으면 하는 부분이 있으면 적어주세요.
- 예) 트랜잭션 범위, 권한 체크, N+1, 상태관리 로직 등
