### PR TITLE
chore: [CHE] BaseEntity 및 JpaAuditingConfig 공통 설정 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/⚙️-chore.md
+++ b/.github/ISSUE_TEMPLATE/⚙️-chore.md
@@ -1,7 +1,7 @@
 ---
 name: ⚙️ Chore
 about: 빌드, 설정, 패키지 등 기타 작업
-title: "[CHORE] "
+title: "[chore] "
 labels: chore
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/src/main/java/com/sparta/delivhub/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/sparta/delivhub/common/config/JpaAuditingConfig.java
@@ -1,0 +1,27 @@
+package com.sparta.delivhub.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder
+                .getContext()
+                .getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return Optional.of("system"); // 미인증 시 system으로
+        }
+
+        return Optional.of(authentication.getName());
+    }
+}

--- a/src/main/java/com/sparta/delivhub/common/entity/BaseEntity.java
+++ b/src/main/java/com/sparta/delivhub/common/entity/BaseEntity.java
@@ -1,0 +1,49 @@
+package com.sparta.delivhub.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private String deletedBy;
+
+    public void softDelete(String deletedBy) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #11

---
## 📌 작업 내용 요약
- [x] BaseEntity 구현
- [x] JpaAuditingConfig 구현
- [x] softDelete 메서드 구현

---
## 🧱 변경 범위 (Scope)
### Backend
- [x] 기타: 공통 엔티티 및 JPA Auditing 설정

### Frontend
- 해당 없음

---
## 🧪 테스트 내역
### Backend
- [x] 로컬에서 애플리케이션 실행 확인
- [ ] 단위 테스트 통과
- [ ] API 수동 테스트 (Postman / Swagger 등)

### Frontend
- 해당 없음

### 테스트 상세(필수)
- 애플리케이션 정상 실행 확인

---
## 🖼️ 화면 캡처 / 시연 영상
- 해당 없음

---
## ⚠️ 영향도 / 리스크 / 롤백
- 영향도: 기존 API 응답 변경 없음
- 리스크: 엔티티 개발 시 BaseEntity 상속 필요
- 롤백 방법: revert 커밋

---
## ✅ 리뷰어 체크 포인트
- 엔티티 개발 시 BaseEntity 상속받아 구현해주세요
- p_order_item, p_ai_log 처럼 수정/삭제 없는 테이블은 BaseEntity 상속 X