### PR TITLE
feat: [CHE] Menu 엔티티 및 레포지토리 구현

### DIFF
--- a/src/main/java/com/sparta/delivhub/domain/ai/entity/AiLog.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/entity/AiLog.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 @Getter
 @Entity
-@Table(name = "ai_logs")
+@Table(name = "p_ai_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class AiLog {

--- a/src/main/java/com/sparta/delivhub/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/controller/MenuController.java
@@ -1,0 +1,7 @@
+package com.sparta.delivhub.domain.menu.controller;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class MenuController {
+}

--- a/src/main/java/com/sparta/delivhub/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/controller/MenuController.java
@@ -1,7 +1,7 @@
 package com.sparta.delivhub.domain.menu.controller;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 public class MenuController {
 }

--- a/src/main/java/com/sparta/delivhub/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/entity/Menu.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 @Getter
 @Entity
-@Table(name = "menus")
+@Table(name = "p_menu")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Menu extends BaseEntity {
     @Id

--- a/src/main/java/com/sparta/delivhub/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/entity/Menu.java
@@ -1,0 +1,58 @@
+package com.sparta.delivhub.domain.menu.entity;
+
+import com.sparta.delivhub.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.sparta.delivhub.domain.store.entity.Store;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "menus")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Menu extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "is_hidden", nullable = false)
+    private boolean isHidden = false;
+
+    @Builder
+    public Menu(Store store, String name, Integer price, String description) {
+        this.store = store;
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.isHidden = false;
+    }
+
+    public void update(String name, Integer price, String description) {
+        if (name != null) this.name = name;
+        if (price != null) this.price = price;
+        if (description != null) this.description = description;
+    }
+
+    public void updateHidden(boolean isHidden) {
+        this.isHidden = isHidden;
+    }
+}
+

--- a/src/main/java/com/sparta/delivhub/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,22 @@
+package com.sparta.delivhub.domain.menu.repository;
+
+import com.sparta.delivhub.domain.menu.entity.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, UUID> {
+    // 가게별 메뉴 목록 조회(삭제x)
+    Page<Menu> findByStoreIdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
+
+    // 가게별 메뉴 목록 조회(숨김x + 삭제x)
+    Page<Menu> findByStoreIdAndIsHiddenFalseAndDeletedAtIsNull(UUID storeId, Pageable pageable);
+
+    // 단건 조회(삭제x)
+    Optional<Menu> findByIdAndDeletedAtIsNull(UUID id);
+}

--- a/src/main/java/com/sparta/delivhub/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/service/MenuService.java
@@ -1,0 +1,7 @@
+package com.sparta.delivhub.domain.menu.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MenuService {
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes: #18

---
## 📌 작업 내용 요약
- [x] Menu 엔티티 구현
- [x] MenuRepository 구현
- [x] MenuService & MenuController 구현(틀만)

---
## 🧱 변경 범위 (Scope)
### Backend
- [x] DB 스키마/쿼리

### Frontend
- 해당 없음

---
## 🧪 테스트 내역
### Backend
- [x] 로컬에서 애플리케이션 실행 확인
- [ ] 단위 테스트 통과
- [ ] API 수동 테스트 (Postman / Swagger 등)

### Frontend
- 해당 없음

### 테스트 상세(필수)
- Store 엔티티 미완성으로 인해 로컬 실행 후 API 테스트 미진행
- Store 엔티티 머지 후 테스트 예정

---
## 🖼️ 화면 캡처 / 시연 영상
- 해당 없음

---
## ⚠️ 영향도 / 리스크 / 롤백
- 영향도: 기존 API 응답 변경 없음
- 리스크: Store 엔티티 의존성 있어 Store 머지 전 단독 실행 불가
- 롤백 방법: revert 커밋

---
## ✅ 리뷰어 체크 포인트
- Store 엔티티 머지 후 실행 확인 필요
- 메뉴 등록 시 옵션 같이 생성 (한 트랜잭션 처리)
- aiDescription: true일 때 AiService 호출 예정 (추후 구현)