### PR TITLE
feat: [CHE] Gemini API 연동 및 AI 로그 조회 구현

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+DB_NAME=delivhub
+DB_USERNAME=사용자 이름
+DB_PASSWORD=비밀번호
+GEMINI_API_KEY=API 키

--- a/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_INPUT_DATA(HttpStatus.BAD_REQUEST, "C002", "입력 데이터가 올바르지 않습니다."),
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "C003", "필수 입력값이 누락되었습니다."),
     NO_CHANGES_DETECTED(HttpStatus.BAD_REQUEST, "C004", "변경할 내용이 없습니다."),
+    INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "C005", "페이징 size는 10, 30, 50만 허용됩니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류가 발생했습니다."),
 
     // 2. User (회원 및 검증 로직)
@@ -81,7 +82,6 @@ public enum ErrorCode {
     MENU_NOT_FOUND_ON_UPDATE_STATUS(HttpStatus.NOT_FOUND, "M008", "존재하지 않는 메뉴입니다."),
     MENU_FORBIDDEN_ON_DELETE(HttpStatus.FORBIDDEN, "M009", "본인 가게의 메뉴만 삭제할 수 있습니다."),
     MENU_NOT_FOUND_ON_DELETE(HttpStatus.NOT_FOUND, "M010", "존재하지 않는 메뉴입니다."),
-    MENU_INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "M011", "페이징 size는 10, 30, 50만 허용됩니다."),
 
     // 9. Option (옵션 로직)
     OPTION_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "OP001", "누락된 값이 있습니다."),

--- a/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
@@ -148,7 +148,8 @@ public enum ErrorCode {
     // 13. AI Log (AI 시스템 로직)
     AI_LOG_FORBIDDEN(HttpStatus.FORBIDDEN, "AI001", "AI 로그 접근은 관리자(MANAGER, MASTER)만 가능합니다."),
     AI_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "AI002", "존재하지 않는 AI 로그입니다."),
-    AI_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI003", "AI 응답을 받지 못했습니다.");
+    AI_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI003", "AI 응답을 받지 못했습니다."),
+    AI_PROMPT_REQUIRED(HttpStatus.BAD_REQUEST, "AI004", "AI 설명 생성을 위해 프롬프트를 입력해야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
@@ -149,7 +149,8 @@ public enum ErrorCode {
     AI_LOG_FORBIDDEN(HttpStatus.FORBIDDEN, "AI001", "AI 로그 접근은 관리자(MANAGER, MASTER)만 가능합니다."),
     AI_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "AI002", "존재하지 않는 AI 로그입니다."),
     AI_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI003", "AI 응답을 받지 못했습니다."),
-    AI_PROMPT_REQUIRED(HttpStatus.BAD_REQUEST, "AI004", "AI 설명 생성을 위해 프롬프트를 입력해야 합니다.");
+    AI_PROMPT_REQUIRED(HttpStatus.BAD_REQUEST, "AI004", "AI 설명 생성을 위해 프롬프트를 입력해야 합니다."),
+    AI_PROMPT_TOO_LONG(HttpStatus.BAD_REQUEST, "AI005", "AI 프롬프트는 100자 이하여야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/sparta/delivhub/common/util/PageableUtils.java
+++ b/src/main/java/com/sparta/delivhub/common/util/PageableUtils.java
@@ -1,0 +1,25 @@
+package com.sparta.delivhub.common.util;
+
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+public class PageableUtils {
+
+    private static final List<Integer> ALLOWED_SIZES = List.of(10, 30, 50);
+
+    public static Pageable of(int page, int size, String sort) {
+        if (!ALLOWED_SIZES.contains(size)) {
+            throw new BusinessException(ErrorCode.INVALID_PAGE_SIZE);
+        }
+        String[] sortParams = sort.split(",");
+        Sort.Direction direction = sortParams.length > 1
+                ? Sort.Direction.fromString(sortParams[1])
+                : Sort.Direction.DESC;
+        return PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
+    }
+}

--- a/src/main/java/com/sparta/delivhub/config/RestClientConfig.java
+++ b/src/main/java/com/sparta/delivhub/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.sparta.delivhub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+    }
+}

--- a/src/main/java/com/sparta/delivhub/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivhub/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .sessionManagement(session->session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(ex->ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth->auth
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(PUBLIC_URLS).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/sparta/delivhub/domain/ai/controller/AiLogController.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/controller/AiLogController.java
@@ -1,0 +1,44 @@
+package com.sparta.delivhub.domain.ai.controller;
+
+import com.sparta.delivhub.common.dto.ApiResponse;
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
+import com.sparta.delivhub.common.util.PageableUtils;
+import com.sparta.delivhub.domain.ai.dto.ResponseAiLogDto;
+import com.sparta.delivhub.domain.ai.service.AiLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ai")
+public class AiLogController {
+    private final AiLogService aiLogService;
+
+    // AI 로그 전체 조회
+    @GetMapping("/logs")
+    public ResponseEntity<ApiResponse<Page<ResponseAiLogDto>>> getAiLogs(
+            @RequestParam(required = false) String username,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt,DESC") String sort) {
+        Pageable pageable = PageableUtils.of(page, size, sort);
+        Page<ResponseAiLogDto> response = aiLogService.getAiLogs(username, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // AI 로그 단건 조회
+    @GetMapping("/logs/{logId}")
+    public ResponseEntity<ApiResponse<ResponseAiLogDto>> getAiLog(
+            @PathVariable UUID logId) {
+        ResponseAiLogDto response = aiLogService.getAiLog(logId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/ai/dto/ResponseAiDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/dto/ResponseAiDto.java
@@ -1,0 +1,20 @@
+package com.sparta.delivhub.domain.ai.dto;
+
+
+import java.util.List;
+
+public record ResponseAiDto(
+        List<Candidate> candidates
+) {
+    public record Candidate(
+            Content content
+    ) {}
+
+    public record Content(
+            List<Part> parts
+    ) {}
+
+    public record Part(
+            String text
+    ) {}
+}

--- a/src/main/java/com/sparta/delivhub/domain/ai/dto/ResponseAiLogDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/dto/ResponseAiLogDto.java
@@ -1,0 +1,34 @@
+package com.sparta.delivhub.domain.ai.dto;
+
+import com.sparta.delivhub.domain.ai.entity.AiLog;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResponseAiLogDto {
+    private UUID aiLogId;
+    private String userId;
+    private String requestText;
+    private String responseText;
+    private String requestType;
+    private LocalDateTime createdAt;
+    private String createdBy;
+
+    public static ResponseAiLogDto from(AiLog aiLog) {
+        return ResponseAiLogDto.builder()
+                .aiLogId(aiLog.getId())
+                .userId(aiLog.getUserId())
+                .requestText(aiLog.getRequestText())
+                .responseText(aiLog.getResponseText())
+                .requestType(aiLog.getRequestType())
+                .createdAt(aiLog.getCreatedAt())
+                .createdBy(aiLog.getCreatedBy())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/ai/entity/AiLog.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/entity/AiLog.java
@@ -40,10 +40,11 @@ public class AiLog {
     private String createdBy;
 
     @Builder
-    public AiLog(String userId, String requestText, String responseText, String requestType) {
+    public AiLog(String userId, String requestText, String responseText, String requestType, LocalDateTime createdAt) {
         this.userId = userId;
         this.requestText = requestText;
         this.responseText = responseText;
         this.requestType = requestType;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/sparta/delivhub/domain/ai/service/AiLogService.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/service/AiLogService.java
@@ -1,0 +1,40 @@
+package com.sparta.delivhub.domain.ai.service;
+
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
+import com.sparta.delivhub.domain.ai.dto.ResponseAiLogDto;
+import com.sparta.delivhub.domain.ai.entity.AiLog;
+import com.sparta.delivhub.domain.ai.repository.AiLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiLogService {
+    private final AiLogRepository aiLogRepository;
+
+    // AI 로그 전체 조회
+    public Page<ResponseAiLogDto> getAiLogs(String username, Pageable pageable) {
+        // TODO: Security 완성 후 MANAGER/MASTER 권한 체크 추가
+        if (username != null) {
+            return aiLogRepository.findByUserId(username, pageable)
+                    .map(ResponseAiLogDto::from);
+        }
+        return aiLogRepository.findAll(pageable)
+                .map(ResponseAiLogDto::from);
+    }
+
+    // AI 로그 단건 조회
+    public ResponseAiLogDto getAiLog(UUID logId) {
+        // TODO: Security 완성 후 MANAGER/MASTER 권한 체크 추가
+        AiLog aiLog = aiLogRepository.findById(logId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AI_LOG_NOT_FOUND));
+        return ResponseAiLogDto.from(aiLog);
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/service/AiService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 @Slf4j
 public class AiService {
     private final AiLogRepository aiLogRepository;
+    private final RestClient restClient;
 
     @Value("${gemini.api.key}")
     private String geminiApiKey;
@@ -30,9 +31,11 @@ public class AiService {
     private static final String SUFFIX_PROMPT =  " 배달음식 플랫폼의 메뉴 소개글처럼 작성하고, 고객이 바로 이해할 수 있게 자연스럽고 간결한 한 줄로 50자 이하로 답변해줘.";
 
     public String generateDescription(String userId, String prompt) {
+        if (prompt.length() > 100) {
+            throw new BusinessException(ErrorCode.AI_PROMPT_TOO_LONG);
+        }
         String fullPrompt = prompt + SUFFIX_PROMPT;
 
-        RestClient restClient = RestClient.create();
 
         Map<String, Object> requestBody = Map.of(
                 "contents", List.of(

--- a/src/main/java/com/sparta/delivhub/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/delivhub/domain/ai/service/AiService.java
@@ -1,0 +1,81 @@
+package com.sparta.delivhub.domain.ai.service;
+
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
+import com.sparta.delivhub.domain.ai.dto.ResponseAiDto;
+import com.sparta.delivhub.domain.ai.entity.AiLog;
+import com.sparta.delivhub.domain.ai.repository.AiLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiService {
+    private final AiLogRepository aiLogRepository;
+
+    @Value("${gemini.api.key}")
+    private String geminiApiKey;
+
+    private static final String GEMINI_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+    private static final String SUFFIX_PROMPT =  " 배달음식 플랫폼의 메뉴 소개글처럼 작성하고, 고객이 바로 이해할 수 있게 자연스럽고 간결한 한 줄로 50자 이하로 답변해줘.";
+
+    public String generateDescription(String userId, String prompt) {
+        String fullPrompt = prompt + SUFFIX_PROMPT;
+
+        RestClient restClient = RestClient.create();
+
+        Map<String, Object> requestBody = Map.of(
+                "contents", List.of(
+                        Map.of("parts", List.of(
+                                Map.of("text", fullPrompt)
+                        ))
+                )
+        );
+
+        ResponseAiDto response;
+        try {
+            response = restClient.post()
+                    .uri(GEMINI_URL + "?key=" + geminiApiKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(ResponseAiDto.class);
+        } catch (Exception e) {
+            log.error("Gemini API 호출 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.AI_API_ERROR);
+        }
+
+        String result = extractText(response);
+
+        aiLogRepository.save(AiLog.builder()
+                .userId(userId)
+                .requestText(prompt)
+                .responseText(result)
+                .requestType("PRODUCT_DESCRIPTION")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        return result;
+    }
+
+    private String extractText(ResponseAiDto response) {
+        try {
+            return response.candidates().get(0)
+                    .content().parts().get(0)
+                    .text();
+        } catch (Exception e) {
+            log.error("Gemini 응답 파싱 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.AI_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/controller/MenuController.java
@@ -1,8 +1,7 @@
 package com.sparta.delivhub.domain.menu.controller;
 
 import com.sparta.delivhub.common.dto.ApiResponse;
-import com.sparta.delivhub.common.dto.BusinessException;
-import com.sparta.delivhub.common.dto.ErrorCode;
+import com.sparta.delivhub.common.util.PageableUtils;
 import com.sparta.delivhub.domain.menu.dto.CreateMenuDto;
 import com.sparta.delivhub.domain.menu.dto.HiddenMenuDto;
 import com.sparta.delivhub.domain.menu.dto.ResponseMenuDto;
@@ -12,9 +11,7 @@ import com.sparta.delivhub.domain.menu.service.MenuService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,14 +41,7 @@ public class MenuController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "createdAt,DESC") String sort) {
-        if (size != 10 && size != 30 && size != 50) {
-            throw new BusinessException(ErrorCode.MENU_INVALID_PAGE_SIZE);
-        }
-        String[] sortParams = sort.split(",");
-        Sort.Direction direction = sortParams.length > 1
-                ? Sort.Direction.fromString(sortParams[1])
-                : Sort.Direction.DESC;
-        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
+        Pageable pageable = PageableUtils.of(page, size, sort);
         Page<ResponseMenuListDto> response = menuService.getMenus(storeId, pageable, false);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/sparta/delivhub/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/service/MenuService.java
@@ -2,6 +2,7 @@ package com.sparta.delivhub.domain.menu.service;
 
 import com.sparta.delivhub.common.dto.BusinessException;
 import com.sparta.delivhub.common.dto.ErrorCode;
+import com.sparta.delivhub.domain.ai.service.AiService;
 import com.sparta.delivhub.domain.menu.dto.CreateMenuDto;
 import com.sparta.delivhub.domain.menu.dto.HiddenMenuDto;
 import com.sparta.delivhub.domain.menu.dto.ResponseMenuDto;
@@ -32,6 +33,7 @@ public class MenuService {
     private final MenuRepository menuRepository;
     private final OptionRepository optionRepository;
     private final StoreRepository storeRepository;
+    private final AiService aiService;
 
     // 메뉴 등록
     @Transactional
@@ -43,9 +45,10 @@ public class MenuService {
 
         // AI 설명 생성
         if (Boolean.TRUE.equals(request.getAiDescription())) {
-            String aiPrompt = request.getAiPrompt() + " 50자 이하로";
-            // 추후 AiService 주입 후 구현
-            // description = aiService.generateDescription(username, request.getAiPrompt());
+            if (request.getAiPrompt() == null || request.getAiPrompt().isBlank()) {
+                throw new BusinessException(ErrorCode.AI_PROMPT_REQUIRED);
+            }
+            description = aiService.generateDescription(username, request.getAiPrompt());
         }
 
         Menu menu = Menu.builder()


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes: #42 

---
## 📌 작업 내용 요약
- [x] Gemini API 연동 및 메뉴 설명 자동 생성 로직 추가
- [x] AI 응답 파싱 DTO 및 AI 요청/응답 로그 저장 기능 구현
- [x] AiLogService 및 AiLogController 구현 (AI 로그 조회)
- [x] PageableUtils 공통 유틸 추가

---
## 🧱 변경 범위 (Scope)
### Backend
- [x] API 추가/수정
- [x] Validation/예외처리
- [x] DB 스키마/쿼리
- [x] 기타: 외부 AI API 연동, AI 로그 저장

### Frontend
- 해당 없음

---
## 🧪 테스트 내역
### Backend
- [x] 로컬에서 애플리케이션 실행 확인
- [x] 단위 테스트 통과
- [x] API 수동 테스트 (Postman / Swagger 등)

### Frontend
- 해당 없음

### 테스트 상세(필수)
- 메뉴 등록 API에서 `aiDescription=true`일 때 AI 설명 생성 동작 확인
- `aiPrompt` 입력 후 메뉴 설명이 자동 생성되는지 확인
- AI 응답 성공 시 `p_ai_log` 테이블에 요청/응답 로그 저장 확인
- `aiPrompt`가 비어 있을 때 예외 응답 확인
- 외부 API 호출 시 429, 503 에러 발생 가능성 확인

---
## 🖼️ 화면 캡처 / 시연 영상
- 해당 없음

---
## ⚠️ 영향도 / 리스크 / 롤백
- 영향도: 메뉴 등록 로직에 AI 설명 생성 분기 추가, 기존 수동 설명 입력 방식은 유지
- 리스크: 외부 Gemini API 상태에 따라 429, 503 등 응답 지연 또는 실패 가능성 있음
- 롤백 방법: AI 설명 생성 분기 제거 또는 `aiDescription` 기능 비활성화 후 revert 커밋 적용

---
## ✅ 리뷰어 체크 포인트
- 메뉴 생성 트랜잭션 내 외부 API 호출 위치가 적절한지
- AI 프롬프트 검증 및 예외 처리 방식이 적절한지
- AI 로그 저장 필드(`createdAt` 포함) 누락 없이 반영되었는지
- 외부 API 실패 시 사용자 응답 처리 방식이 적절한지
- AI 로그 조회는 MANAGER/MASTER 권한 체크 Security 완성 후 추가 예정