### PR TITLE
refactor: [LSG] UserServiceTest 실패 테스트 작성

### DIFF
--- a/src/test/java/com/sparta/delivhub/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/user/service/UserServiceTest.java
@@ -298,7 +298,6 @@ class UserServiceTest {
 
         given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("OldPassword1!", "encodedOldPassword")).willReturn(true);
-        given(passwordEncoder.matches("OldPassword1!", "encodedOldPassword")).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> userService.updatePassword("user01", request))

--- a/src/test/java/com/sparta/delivhub/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/user/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.sparta.delivhub.domain.user.service;
 
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
 import com.sparta.delivhub.common.dto.PageResponse;
 import com.sparta.delivhub.domain.user.dto.UpdatePasswordRequest;
 import com.sparta.delivhub.domain.user.dto.UpdateRoleRequest;
@@ -126,6 +128,19 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("유저_단건_조회_실패_존재X")
+    void getUser_fail_notFound() {
+        // given
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUser("user01"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
     @DisplayName("유저_닉네임_수정_성공")
     void updateUser_success_nickname() {
         // given
@@ -184,6 +199,42 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("유저_정보_수정_실패_변경사항_없음")
+    void updateUser_fail_noChanges() {
+        // given
+        UpdateUserRequest request = mock(UpdateUserRequest.class);
+        given(request.getNickname()).willReturn("홍길동");
+        given(request.getEmail()).willReturn("user01@example.com");
+        given(request.getIsPublic()).willReturn(true);
+
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser("user01", request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NO_CHANGES_DETECTED);
+    }
+
+    @Test
+    @DisplayName("유저_정보_수정_실패_중복_이메일")
+    void updateUser_fail_duplicateEmail() {
+        // given
+        UpdateUserRequest request = mock(UpdateUserRequest.class);
+        given(request.getNickname()).willReturn(null);
+        given(request.getEmail()).willReturn("duplicate@example.com");
+
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.of(user));
+        given(userRepository.existsByEmail("duplicate@example.com")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser("user01", request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+    }
+
+    @Test
     @DisplayName("유저_역할_수정_성공")
     void updateRole_success() {
         // given
@@ -221,6 +272,42 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("비밀번호_변경_실패_현재_비밀번호_불일치")
+    void updatePassword_fail_wrongCurrentPassword() {
+        // given
+        UpdatePasswordRequest request = mock(UpdatePasswordRequest.class);
+        given(request.getCurrentPassword()).willReturn("WrongPassword1!");
+
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("WrongPassword1!", "encodedOldPassword")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updatePassword("user01", request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.WRONG_CURRENT_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("비밀번호_변경_실패_현재_비밀번호와_동일")
+    void updatePassword_fail_sameAsCurrentPassword() {
+        // given
+        UpdatePasswordRequest request = mock(UpdatePasswordRequest.class);
+        given(request.getCurrentPassword()).willReturn("OldPassword1!");
+        given(request.getNewPassword()).willReturn("OldPassword1!");
+
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("OldPassword1!", "encodedOldPassword")).willReturn(true);
+        given(passwordEncoder.matches("OldPassword1!", "encodedOldPassword")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updatePassword("user01", request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PASSWORD_SAME_AS_CURRENT);
+    }
+
+    @Test
     @DisplayName("유저_삭제_성공")
     void deleteUser_success() {
         // given
@@ -232,5 +319,18 @@ class UserServiceTest {
         // then
         verify(userRepository).findByUsernameAndDeletedAtIsNull("user01");
         assertThat(user.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("유저_삭제_실패_존재X")
+    void deleteUser_fail_notFound() {
+        // given
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteUser("user01", "admin"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 진행 중이면 `Refs #123`, 완전 해결이면 `Closes #123` (완전히 끝났을 때만)
- Refs/Closes: #64 

---

## 📌 작업 내용 요약
- [x] 단건 조회 실패 테스트 작성
- [x] 유저 수정 실패 테스트 작성
- [x] 유저 비밀번호 수정 실패 테스트 작성
- [x] 유저 삭제 실패 테스트 작성
---

## 🧱 변경 범위 (Scope)
### Backend
- [ ] API 추가/수정
- [ ] Validation/예외처리
- [ ] 인증/인가
- [ ] DB 스키마/쿼리
- [x] 기타: 테스트 코드

## 🧪 테스트 내역
### Backend
- [x] 로컬에서 애플리케이션 실행 확인
- [x] 단위 테스트 통과

### 테스트 상세(필수)
> 테스트한 API/페이지/케이스를 간단히 적어주세요.
- 예) 로그인 성공/실패, 회원가입, 목록 조회 등

---

## 🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
- before:
- after:

---

## ⚠️ 영향도 / 리스크 / 롤백
> 리뷰어가 “머지해도 되는지” 판단하기 위한 섹션입니다.
- 영향도: (예: 기존 API 응답 변경 없음 / 있음)
- 리스크: (예: 권한 로직 수정, 쿼리 성능, 마이그레이션 필요 등)
- 롤백 방법: (예: revert 커밋 / 기능 플래그 off / 마이그레이션 롤백 불가 등)

---

## ✅ 리뷰어 체크 포인트 (선택)
> 리뷰어가 집중해서 봐줬으면 하는 부분이 있으면 적어주세요.
- 예) 트랜잭션 범위, 권한 체크, N+1, 상태관리 로직 등
