### PR TITLE
refactor: [CHE] 옵션 그룹/아이템 구조 개선 및 주문 옵션 선택 연동

### DIFF
--- a/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
+++ b/src/main/java/com/sparta/delivhub/common/dto/ErrorCode.java
@@ -89,6 +89,9 @@ public enum ErrorCode {
     MENU_NOT_FOUND_ON_OPTION(HttpStatus.NOT_FOUND, "OP003", "존재하지 않는 메뉴입니다."),
     OPTION_FORBIDDEN_ON_UPDATE(HttpStatus.FORBIDDEN, "OP005", "본인 가게의 메뉴에 속한 옵션만 수정할 수 있습니다."),
     OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "OP006", "존재하지 않는 옵션입니다."),
+    OPTION_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "OP007", "존재하지 않는 옵션 아이템입니다."),
+    OPTION_ITEM_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "OP008", "옵션 아이템 정보가 올바르지 않습니다."),
+    OPTION_TYPE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "OP009", "옵션 선택 방식이 올바르지 않습니다."),
 
     // 10. Order (주문 로직)
     ORDER_PARAM_MISSING(HttpStatus.BAD_REQUEST, "OD001", "필수 파라미터 누락"),

--- a/src/main/java/com/sparta/delivhub/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/delivhub/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.sparta.delivhub.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("DelivHub API")
+                        .description("배달 음식 주문 관리 플랫폼 API")
+                        .version("v1.0"))
+                .addSecurityItem(securityRequirement)
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", securityScheme));
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/delivhub/domain/menu/service/MenuService.java
@@ -14,6 +14,7 @@ import com.sparta.delivhub.domain.menu.repository.MenuRepository;
 import com.sparta.delivhub.domain.option.dto.CreateOptionDto;
 import com.sparta.delivhub.domain.option.dto.ResponseOptionDto;
 import com.sparta.delivhub.domain.option.entity.Option;
+import com.sparta.delivhub.domain.option.entity.OptionItem;
 import com.sparta.delivhub.domain.option.repository.OptionRepository;
 import com.sparta.delivhub.domain.store.entity.Store;
 import com.sparta.delivhub.domain.store.repository.StoreRepository;
@@ -69,22 +70,16 @@ public class MenuService {
         menuRepository.save(menu);
 
         // 옵션 같이 생성
-        List<Option> options = new ArrayList<>();
-        if (request.getOptions() != null) {
-            for (CreateOptionDto optionDto : request.getOptions()) {
-                Option option = Option.builder()
-                        .menu(menu)
-                        .name(optionDto.getName())
-                        .extraPrice(optionDto.getExtraPrice())
-                        .build();
-                options.add(option);
-            }
+        List<Option> options = createOptions(menu, request.getOptions());
+
+        if (!options.isEmpty()) {
             optionRepository.saveAll(options);
         }
 
         List<ResponseOptionDto> optionDtos = options.stream()
                 .map(ResponseOptionDto::from)
                 .toList();
+
 
         return ResponseMenuDto.from(menu, optionDtos);
     }
@@ -109,7 +104,7 @@ public class MenuService {
         Menu menu = menuRepository.findByIdAndDeletedAtIsNull(menuId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND_ON_READ));
 
-        List<ResponseOptionDto> options = optionRepository.findByMenuIdAndDeletedAtIsNull(menuId)
+        List<ResponseOptionDto> options = optionRepository.findAllByMenuIdWithItems(menuId)
                 .stream()
                 .map(ResponseOptionDto::from)
                 .toList();
@@ -125,7 +120,7 @@ public class MenuService {
         // 수정
         menu.update(request.getName(), request.getPrice(), request.getDescription());
 
-        List<ResponseOptionDto> options = optionRepository.findByMenuIdAndDeletedAtIsNull(menuId)
+        List<ResponseOptionDto> options = optionRepository.findAllByMenuIdWithItems(menuId)
                 .stream()
                 .map(ResponseOptionDto::from)
                 .toList();
@@ -145,6 +140,36 @@ public class MenuService {
     public void deleteMenu(UUID menuId, String username) {
         Menu menu = getMenuAndCheckPermission(menuId, username, ErrorCode.MENU_NOT_FOUND_ON_DELETE);
         menu.softDelete(username);
+    }
+
+    // 메뉴 생성 시 옵션 그룹 + 옵션 아이템 생성
+    private List<Option> createOptions(Menu menu, List<CreateOptionDto> optionRequests) {
+        if (optionRequests == null || optionRequests.isEmpty()) {
+            return List.of();
+        }
+
+        return optionRequests.stream()
+                .map(optionRequest -> createOption(menu, optionRequest))
+                .toList();
+    }
+    // 옵션 그룹 생성
+    private Option createOption(Menu menu, CreateOptionDto optionRequest) {
+        Option option = Option.builder()
+                .menu(menu)
+                .name(optionRequest.getName())
+                .type(optionRequest.getType())
+                .build();
+
+        for (CreateOptionDto.Item itemRequest : optionRequest.getItems()) {
+            OptionItem optionItem = OptionItem.builder()
+                    .name(itemRequest.getName())
+                    .extraPrice(itemRequest.getExtraPrice())
+                    .build();
+
+            option.addOptionItem(optionItem);
+        }
+
+        return option;
     }
 
     // 메뉴 조회 + 권한 체크

--- a/src/main/java/com/sparta/delivhub/domain/option/dto/CreateOptionDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/dto/CreateOptionDto.java
@@ -1,23 +1,43 @@
 package com.sparta.delivhub.domain.option.dto;
 
+import com.sparta.delivhub.domain.option.entity.OptionType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateOptionDto {
-
-    @NotBlank(message = "옵션명은 필수입니다.")
-    @Size(max = 100, message = "옵션명은 100자 이하여야 합니다.")
+    @NotBlank(message = "옵션 그룹명은 필수입니다.")
+    @Size(max = 100, message = "옵션 그룹명은 100자 이하여야 합니다.")
     private String name;
 
-    @NotNull(message = "추가 금액은 필수입니다.")
-    @Min(value = 0, message = "추가 금액은 0 이상이어야 합니다.")
-    private Long extraPrice;
+    @NotNull(message = "옵션 선택 방식은 필수입니다.")
+    private OptionType type;
+
+    @Valid
+    @NotEmpty(message = "옵션 아이템은 최소 1개 이상 필요합니다.")
+    private List<Item> items;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Item {
+        @NotBlank(message = "옵션 아이템명은 필수입니다.")
+        @Size(max = 100, message = "옵션 아이템명은 100자 이하여야 합니다.")
+        private String name;
+
+        @NotNull(message = "추가 금액은 필수입니다.")
+        @Min(value = 0, message = "추가 금액은 0 이상이어야 합니다.")
+        private Long extraPrice;
+    }
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/dto/ResponseOptionDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/dto/ResponseOptionDto.java
@@ -1,11 +1,13 @@
 package com.sparta.delivhub.domain.option.dto;
 
 import com.sparta.delivhub.domain.option.entity.Option;
+import com.sparta.delivhub.domain.option.entity.OptionType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -15,7 +17,8 @@ public class ResponseOptionDto {
     private UUID optionId;
     private UUID menuId;
     private String name;
-    private Long extraPrice;
+    private OptionType type;
+    private List<Item> items;
     private LocalDateTime createdAt;
     private String createdBy;
 
@@ -24,9 +27,28 @@ public class ResponseOptionDto {
                 .optionId(option.getId())
                 .menuId(option.getMenu().getId())
                 .name(option.getName())
-                .extraPrice(option.getExtraPrice())
+                .type(option.getType())
+                .items(
+                        option.getOptionItems().stream()
+                                .filter(optionItem -> optionItem.getDeletedAt() == null)
+                                .map(optionItem -> Item.builder()
+                                        .optionItemId(optionItem.getId())
+                                        .name(optionItem.getName())
+                                        .extraPrice(optionItem.getExtraPrice())
+                                        .build())
+                                .toList()
+                )
                 .createdAt(option.getCreatedAt())
                 .createdBy(option.getCreatedBy())
                 .build();
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Item {
+        private UUID optionItemId;
+        private String name;
+        private Long extraPrice;
     }
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/dto/UpdateOptionDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/dto/UpdateOptionDto.java
@@ -1,19 +1,38 @@
 package com.sparta.delivhub.domain.option.dto;
 
+import com.sparta.delivhub.domain.option.entity.OptionType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+import java.util.UUID;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateOptionDto {
-
-    @Size(max = 100, message = "옵션명은 100자 이하여야 합니다.")
+    @Size(max = 100, message = "옵션 그룹명은 100자 이하여야 합니다.")
     private String name;
 
-    @Min(value = 0, message = "추가 금액은 0 이상이어야 합니다.")
-    private Long extraPrice;
+    private OptionType type;
+
+    @Valid
+    private List<Item> items;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Item {
+        private UUID optionItemId;
+
+        @Size(max = 100, message = "옵션 아이템명은 100자 이하여야 합니다.")
+        private String name;
+
+        @Min(value = 0, message = "추가 금액은 0 이상이어야 합니다.")
+        private Long extraPrice;
+    }
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/entity/Option.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/entity/Option.java
@@ -7,6 +7,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -23,21 +26,45 @@ public class Option extends BaseEntity {
     @JoinColumn(name = "menu_id", nullable = false)
     private Menu menu;
 
+    // 옵션 그룹명: 예) 맵기 선택, 추가 선택, 사이즈 선택
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
-    @Column(name = "extra_price", nullable = false)
-    private Long extraPrice = 0L;
+    // SINGLE = 1개 선택, MULTIPLE = 여러 개 선택
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private OptionType type;
+
+    @OneToMany(mappedBy = "option", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OptionItem> optionItems = new ArrayList<>();
 
     @Builder
-    public Option(Menu menu, String name, Long extraPrice) {
+    public Option(Menu menu, String name, OptionType type) {
         this.menu = menu;
         this.name = name;
-        this.extraPrice = extraPrice != null ? extraPrice : 0L;
+        this.type = type;
     }
 
-    public void update(String name, Long extraPrice) {
-        if (name != null) this.name = name;
-        if (extraPrice != null) this.extraPrice = extraPrice;
+    public void update(String name, OptionType type) {
+        if (name != null) {
+            this.name = name;
+        }
+
+        if (type != null) {
+            this.type = type;
+        }
+    }
+
+    public void assignMenu(Menu menu) {
+        this.menu = menu;
+    }
+
+    public void addOptionItem(OptionItem optionItem) {
+        this.optionItems.add(optionItem);
+        optionItem.assignOption(this);
+    }
+
+    public void clearOptionItems() {
+        this.optionItems.clear();
     }
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/entity/OptionItem.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/entity/OptionItem.java
@@ -1,0 +1,47 @@
+package com.sparta.delivhub.domain.option.entity;
+
+import com.sparta.delivhub.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "p_option_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionItem extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id", nullable = false)
+    private Option option;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "extra_price", nullable = false)
+    private Long extraPrice = 0L;
+
+    @Builder
+    public OptionItem(Option option, String name, Long extraPrice) {
+        this.option = option;
+        this.name = name;
+        this.extraPrice = extraPrice != null ? extraPrice : 0L;
+    }
+
+    public void update(String name, Long extraPrice) {
+        if (name != null) this.name = name;
+        if (extraPrice != null) this.extraPrice = extraPrice;
+    }
+
+    public void assignOption(Option option) {
+        this.option = option;
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/option/entity/OptionType.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/entity/OptionType.java
@@ -1,0 +1,6 @@
+package com.sparta.delivhub.domain.option.entity;
+
+public enum OptionType {
+    SINGLE,
+    MULTIPLE
+}

--- a/src/main/java/com/sparta/delivhub/domain/option/repository/OptionItemRepository.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/repository/OptionItemRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.delivhub.domain.option.repository;
 
 import com.sparta.delivhub.domain.option.entity.OptionItem;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +12,6 @@ import java.util.UUID;
 @Repository
 public interface OptionItemRepository extends JpaRepository<OptionItem, UUID> {
     // 주문 생성 시 선택한 옵션 아이템 목록 조회
+    @EntityGraph(attributePaths = {"option", "option.menu"})
     List<OptionItem> findByIdInAndDeletedAtIsNull(Collection<UUID> ids);
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/repository/OptionItemRepository.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/repository/OptionItemRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.delivhub.domain.option.repository;
+
+import com.sparta.delivhub.domain.option.entity.OptionItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface OptionItemRepository extends JpaRepository<OptionItem, UUID> {
+    // 주문 생성 시 선택한 옵션 아이템 목록 조회
+    List<OptionItem> findByIdInAndDeletedAtIsNull(Collection<UUID> ids);
+}

--- a/src/main/java/com/sparta/delivhub/domain/option/repository/OptionRepository.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/repository/OptionRepository.java
@@ -21,9 +21,6 @@ public interface OptionRepository extends JpaRepository<Option, UUID> {
     // 메뉴에 속한 특정 옵션 그룹 조회(삭제x)
     Optional<Option> findByIdAndMenuIdAndDeletedAtIsNull(UUID id, UUID menuId);
 
-    // 메뉴별 옵션 그룹 존재 여부 확인(삭제x)
-    boolean existsByMenuIdAndDeletedAtIsNull(UUID menuId);
-
     // 메뉴별 옵션 그룹 + 옵션 아이템 함께 조회
     @Query("""
         select distinct o
@@ -34,19 +31,4 @@ public interface OptionRepository extends JpaRepository<Option, UUID> {
           and (oi.deletedAt is null or oi.id is null)
     """)
     List<Option> findAllByMenuIdWithItems(@Param("menuId") UUID menuId);
-
-    // 특정 옵션 그룹 + 옵션 아이템 함께 조회
-    @Query("""
-        select distinct o
-        from Option o
-        left join fetch o.optionItems oi
-        where o.id = :optionId
-          and o.menu.id = :menuId
-          and o.deletedAt is null
-          and (oi.deletedAt is null or oi.id is null)
-    """)
-    Optional<Option> findByIdAndMenuIdWithItems(
-            @Param("optionId") UUID optionId,
-            @Param("menuId") UUID menuId
-    );
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/repository/OptionRepository.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/repository/OptionRepository.java
@@ -2,6 +2,8 @@ package com.sparta.delivhub.domain.option.repository;
 
 import com.sparta.delivhub.domain.option.entity.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,9 +12,41 @@ import java.util.UUID;
 
 @Repository
 public interface OptionRepository extends JpaRepository<Option, UUID> {
-    // 메뉴별 옵션 목록 조회(삭제x)
+    // 메뉴별 옵션 그룹 목록 조회(삭제x)
     List<Option> findByMenuIdAndDeletedAtIsNull(UUID menuId);
 
-    // 단건 조회(삭제x)
+    // 단건 옵션 그룹 조회(삭제x)
     Optional<Option> findByIdAndDeletedAtIsNull(UUID id);
+
+    // 메뉴에 속한 특정 옵션 그룹 조회(삭제x)
+    Optional<Option> findByIdAndMenuIdAndDeletedAtIsNull(UUID id, UUID menuId);
+
+    // 메뉴별 옵션 그룹 존재 여부 확인(삭제x)
+    boolean existsByMenuIdAndDeletedAtIsNull(UUID menuId);
+
+    // 메뉴별 옵션 그룹 + 옵션 아이템 함께 조회
+    @Query("""
+        select distinct o
+        from Option o
+        left join fetch o.optionItems oi
+        where o.menu.id = :menuId
+          and o.deletedAt is null
+          and (oi.deletedAt is null or oi.id is null)
+    """)
+    List<Option> findAllByMenuIdWithItems(@Param("menuId") UUID menuId);
+
+    // 특정 옵션 그룹 + 옵션 아이템 함께 조회
+    @Query("""
+        select distinct o
+        from Option o
+        left join fetch o.optionItems oi
+        where o.id = :optionId
+          and o.menu.id = :menuId
+          and o.deletedAt is null
+          and (oi.deletedAt is null or oi.id is null)
+    """)
+    Optional<Option> findByIdAndMenuIdWithItems(
+            @Param("optionId") UUID optionId,
+            @Param("menuId") UUID menuId
+    );
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/repository/OptionRepository.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/repository/OptionRepository.java
@@ -31,4 +31,18 @@ public interface OptionRepository extends JpaRepository<Option, UUID> {
           and (oi.deletedAt is null or oi.id is null)
     """)
     List<Option> findAllByMenuIdWithItems(@Param("menuId") UUID menuId);
+
+    @Query("""
+        select distinct o
+        from Option o
+        left join fetch o.optionItems oi
+        where o.id = :optionId
+          and o.menu.id = :menuId
+          and o.deletedAt is null
+          and (oi.deletedAt is null or oi.id is null)
+    """)
+    Optional<Option> findByIdAndMenuIdWithItems(
+            @Param("optionId") UUID optionId,
+            @Param("menuId") UUID menuId
+    );
 }

--- a/src/main/java/com/sparta/delivhub/domain/option/service/OptionService.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/service/OptionService.java
@@ -39,6 +39,7 @@ public class OptionService {
         Option option = Option.builder()
                 .menu(menu)
                 .name(request.getName())
+                .type(request.getType())
                 .build();
 
         // 옵션 아이템 생성
@@ -79,7 +80,7 @@ public class OptionService {
         option.update(request.getName(), request.getType());
 
         if (request.getItems() != null) {
-            updateOptionItems(option, request.getItems());
+            updateOptionItems(option, request.getItems(), username);
         }
 
         return ResponseOptionDto.from(option);
@@ -87,17 +88,18 @@ public class OptionService {
 
 
     // 옵션 아이템 수정/추가/삭제
-    private void updateOptionItems(Option option, List<UpdateOptionDto.Item> itemRequests) {
+    private void updateOptionItems(Option option, List<UpdateOptionDto.Item> itemRequests, String username) {
         List<UUID> requestItemIds = itemRequests.stream()
                 .map(UpdateOptionDto.Item::getOptionItemId)
                 .filter(Objects::nonNull)
                 .toList();
 
         // 요청에 없는 기존 아이템은 삭제
-        option.getOptionItems().removeIf(optionItem ->
-                optionItem.getDeletedAt() == null
-                        && !requestItemIds.contains(optionItem.getId())
-        );
+        option.getOptionItems().stream()
+                .filter(optionItem -> optionItem.getDeletedAt() == null)
+                .filter(optionItem -> !requestItemIds.contains(optionItem.getId()))
+                .forEach(optionItem -> optionItem.softDelete(username));
+
 
         for (UpdateOptionDto.Item itemRequest : itemRequests) {
             if (itemRequest.getOptionItemId() == null) {
@@ -113,10 +115,13 @@ public class OptionService {
     public void deleteOption(UUID menuId, UUID optionId, String username) {
         getMenuAndCheckPermission(menuId, username);
 
-        Option option = optionRepository.findByIdAndDeletedAtIsNull(optionId)
+        Option option = optionRepository.findByIdAndMenuIdWithItems(optionId, menuId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.OPTION_NOT_FOUND));
 
         option.softDelete(username);
+        option.getOptionItems().stream()
+                .filter(optionItem -> optionItem.getDeletedAt() == null)
+                .forEach(optionItem -> optionItem.softDelete(username));
     }
 
     // 새 옵션 아이템 추가

--- a/src/main/java/com/sparta/delivhub/domain/option/service/OptionService.java
+++ b/src/main/java/com/sparta/delivhub/domain/option/service/OptionService.java
@@ -9,6 +9,7 @@ import com.sparta.delivhub.domain.option.dto.CreateOptionDto;
 import com.sparta.delivhub.domain.option.dto.ResponseOptionDto;
 import com.sparta.delivhub.domain.option.dto.UpdateOptionDto;
 import com.sparta.delivhub.domain.option.entity.Option;
+import com.sparta.delivhub.domain.option.entity.OptionItem;
 import com.sparta.delivhub.domain.option.repository.OptionRepository;
 import com.sparta.delivhub.domain.user.entity.User;
 import com.sparta.delivhub.domain.user.repository.UserRepository;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -33,39 +35,77 @@ public class OptionService {
     public ResponseOptionDto createOption(UUID menuId, CreateOptionDto request, String username) {
         Menu menu = getMenuAndCheckPermission(menuId, username);
 
+        // 옵션 그룹 생성
         Option option = Option.builder()
                 .menu(menu)
                 .name(request.getName())
-                .extraPrice(request.getExtraPrice())
                 .build();
+
+        // 옵션 아이템 생성
+        for (CreateOptionDto.Item itemRequest : request.getItems()) {
+            OptionItem optionItem = OptionItem.builder()
+                    .name(itemRequest.getName())
+                    .extraPrice(itemRequest.getExtraPrice())
+                    .build();
+
+            option.addOptionItem(optionItem);
+        }
 
         optionRepository.save(option);
         return ResponseOptionDto.from(option);
     }
 
-    // 옵션 목록 조회
+    // 옵션 그룹 목록 조회
     public List<ResponseOptionDto> getOptions(UUID menuId) {
         menuRepository.findByIdAndDeletedAtIsNull(menuId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND_ON_OPTION));
 
-        return optionRepository.findByMenuIdAndDeletedAtIsNull(menuId)
+        return optionRepository.findAllByMenuIdWithItems(menuId)
                 .stream()
                 .map(ResponseOptionDto::from)
                 .toList();
     }
 
-    // 옵션 수정
+    // 옵션 그룹 + 옵션 아이템 수정
     @Transactional
     public ResponseOptionDto updateOption(
             UUID menuId, UUID optionId, UpdateOptionDto request, String username
     ) {
         getMenuAndCheckPermission(menuId, username);
 
-        Option option = optionRepository.findByIdAndDeletedAtIsNull(optionId)
+        Option option = optionRepository.findByIdAndMenuIdAndDeletedAtIsNull(optionId, menuId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.OPTION_NOT_FOUND));
 
-        option.update(request.getName(), request.getExtraPrice());
+        option.update(request.getName(), request.getType());
+
+        if (request.getItems() != null) {
+            updateOptionItems(option, request.getItems());
+        }
+
         return ResponseOptionDto.from(option);
+    }
+
+
+    // 옵션 아이템 수정/추가/삭제
+    private void updateOptionItems(Option option, List<UpdateOptionDto.Item> itemRequests) {
+        List<UUID> requestItemIds = itemRequests.stream()
+                .map(UpdateOptionDto.Item::getOptionItemId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        // 요청에 없는 기존 아이템은 삭제
+        option.getOptionItems().removeIf(optionItem ->
+                optionItem.getDeletedAt() == null
+                        && !requestItemIds.contains(optionItem.getId())
+        );
+
+        for (UpdateOptionDto.Item itemRequest : itemRequests) {
+            if (itemRequest.getOptionItemId() == null) {
+                addNewOptionItem(option, itemRequest);
+            } else {
+                updateExistingOptionItem(option, itemRequest);
+            }
+        }
     }
 
     // 옵션 삭제
@@ -78,6 +118,28 @@ public class OptionService {
 
         option.softDelete(username);
     }
+
+    // 새 옵션 아이템 추가
+    private void addNewOptionItem(Option option, UpdateOptionDto.Item itemRequest) {
+        OptionItem optionItem = OptionItem.builder()
+                .name(itemRequest.getName())
+                .extraPrice(itemRequest.getExtraPrice())
+                .build();
+
+        option.addOptionItem(optionItem);
+    }
+
+    // 기존 옵션 아이템 수정
+    private void updateExistingOptionItem(Option option, UpdateOptionDto.Item itemRequest) {
+        OptionItem optionItem = option.getOptionItems().stream()
+                .filter(item -> item.getDeletedAt() == null)
+                .filter(item -> item.getId().equals(itemRequest.getOptionItemId()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.OPTION_ITEM_NOT_FOUND));
+
+        optionItem.update(itemRequest.getName(), itemRequest.getExtraPrice());
+    }
+
 
     // 메뉴 조회 + 권한 체크
     private Menu getMenuAndCheckPermission(UUID menuId, String username) {

--- a/src/main/java/com/sparta/delivhub/domain/order/service/dto/OrderRequestDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/order/service/dto/OrderRequestDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,5 +39,8 @@ public class OrderRequestDto {
 
         @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
         private Integer quantity;
+
+        @Builder.Default
+        private List<UUID> optionItemIds = new ArrayList<>();
     }
 }

--- a/src/main/java/com/sparta/delivhub/domain/order/service/dto/OrderResponseDto.java
+++ b/src/main/java/com/sparta/delivhub/domain/order/service/dto/OrderResponseDto.java
@@ -1,6 +1,7 @@
 package com.sparta.delivhub.domain.order.service.dto;
 
 import com.sparta.delivhub.domain.order.service.entity.Order;
+import com.sparta.delivhub.domain.order.service.entity.OrderItemOption;
 import com.sparta.delivhub.domain.order.service.entity.OrderStatus;
 import com.sparta.delivhub.domain.order.service.entity.OrderItem;
 import lombok.Builder;
@@ -41,13 +42,36 @@ public class OrderResponseDto {
         private UUID menuId;
         private Integer quantity;
         private Long unitPrice;
+        private List<OrderItemOptionResponseDto> options;
 
         public static OrderItemResponseDto from(OrderItem item) {
             return OrderItemResponseDto.builder()
                 .menuId(item.getMenuId())
                 .quantity(item.getQuantity())
                 .unitPrice(item.getUnitPrice())
+                .options(item.getOptions().stream()
+                    .map(OrderItemOptionResponseDto::from)
+                    .toList())
                 .build();
+        }
+    }
+    @Getter
+    @Builder
+    public static class OrderItemOptionResponseDto {
+        private UUID optionId;
+        private String optionName;
+        private UUID optionItemId;
+        private String optionItemName;
+        private Long extraPrice;
+
+        public static OrderItemOptionResponseDto from(OrderItemOption option) {
+            return OrderItemOptionResponseDto.builder()
+                    .optionId(option.getOptionId())
+                    .optionName(option.getOptionName())
+                    .optionItemId(option.getOptionItemId())
+                    .optionItemName(option.getOptionItemName())
+                    .extraPrice(option.getExtraPrice())
+                    .build();
         }
     }
 }

--- a/src/main/java/com/sparta/delivhub/domain/order/service/entity/OrderItem.java
+++ b/src/main/java/com/sparta/delivhub/domain/order/service/entity/OrderItem.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -33,6 +35,9 @@ public class OrderItem extends BaseEntity {
     @Column(name = "unit_price", nullable = false)
     private Long unitPrice;
 
+    @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItemOption> options = new ArrayList<>();
+
     @Builder
     public OrderItem(UUID menuId, Integer quantity, Long unitPrice) {
         this.menuId = menuId;
@@ -42,5 +47,10 @@ public class OrderItem extends BaseEntity {
 
     protected void setOrder(Order order) {
         this.order = order;
+    }
+
+    public void addOption(OrderItemOption option) {
+        this.options.add(option);
+        option.setOrderItem(this);
     }
 }

--- a/src/main/java/com/sparta/delivhub/domain/order/service/entity/OrderItemOption.java
+++ b/src/main/java/com/sparta/delivhub/domain/order/service/entity/OrderItemOption.java
@@ -1,0 +1,60 @@
+package com.sparta.delivhub.domain.order.service.entity;
+
+import com.sparta.delivhub.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_order_item_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItemOption extends BaseEntity {
+    @Id
+    @UuidGenerator
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
+
+    @Column(name = "option_id", nullable = false)
+    private UUID optionId;
+
+    @Column(name = "option_name", nullable = false, length = 100)
+    private String optionName;
+
+    @Column(name = "option_item_id", nullable = false)
+    private UUID optionItemId;
+
+    @Column(name = "option_item_name", nullable = false, length = 100)
+    private String optionItemName;
+
+    @Column(name = "extra_price", nullable = false)
+    private Long extraPrice;
+
+    @Builder
+    public OrderItemOption(
+            UUID optionId,
+            String optionName,
+            UUID optionItemId,
+            String optionItemName,
+            Long extraPrice
+    ) {
+        this.optionId = optionId;
+        this.optionName = optionName;
+        this.optionItemId = optionItemId;
+        this.optionItemName = optionItemName;
+        this.extraPrice = extraPrice != null ? extraPrice : 0L;
+    }
+
+    protected void setOrderItem(OrderItem orderItem) {
+        this.orderItem = orderItem;
+    }
+}

--- a/src/main/java/com/sparta/delivhub/domain/order/service/service/OrderService.java
+++ b/src/main/java/com/sparta/delivhub/domain/order/service/service/OrderService.java
@@ -1,10 +1,17 @@
 package com.sparta.delivhub.domain.order.service.service;
 
+import com.sparta.delivhub.common.dto.BusinessException;
 import com.sparta.delivhub.common.dto.ErrorCode;
+import com.sparta.delivhub.domain.menu.entity.Menu;
+import com.sparta.delivhub.domain.menu.repository.MenuRepository;
+import com.sparta.delivhub.domain.option.entity.OptionItem;
+import com.sparta.delivhub.domain.option.entity.OptionType;
+import com.sparta.delivhub.domain.option.repository.OptionItemRepository;
 import com.sparta.delivhub.domain.order.service.dto.OrderRequestDto;
 import com.sparta.delivhub.domain.order.service.dto.OrderResponseDto;
 import com.sparta.delivhub.domain.order.service.entity.Order;
 import com.sparta.delivhub.domain.order.service.entity.OrderItem;
+import com.sparta.delivhub.domain.order.service.entity.OrderItemOption;
 import com.sparta.delivhub.domain.order.service.entity.OrderStatus;
 import com.sparta.delivhub.domain.order.service.exception.OrderCancellationNotAllowedException;
 import com.sparta.delivhub.domain.order.service.exception.OrderNotFoundException;
@@ -23,7 +30,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +43,8 @@ public class OrderService {
     private static final int ORDER_CANCEL_LIMIT_MINUTES = 5;
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
+    private final MenuRepository menuRepository;
+    private final OptionItemRepository optionItemRepository;
 
     @Transactional
     public OrderResponseDto createOrder(OrderRequestDto requestDto, String userId) {
@@ -40,12 +52,36 @@ public class OrderService {
         List<OrderItem> orderItems = new java.util.ArrayList<>();
 
         for (OrderRequestDto.OrderItemRequestDto itemDto : requestDto.getItems()) {
-            long unitPrice = getActualMenuPrice(itemDto.getMenuId());
+            Menu menu = menuRepository.findByIdAndDeletedAtIsNull(itemDto.getMenuId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND_ON_READ));
+
+            validateMenuBelongsToStore(menu, requestDto.getStoreId());
+            List<OptionItem> optionItems = getOptionItems(itemDto.getOptionItemIds());
+            validateOptionItemsBelongToMenu(optionItems, itemDto.getMenuId());
+            validateSingleOptionSelection(optionItems);
+
+            long optionExtraPrice = optionItems.stream()
+                    .mapToLong(OptionItem::getExtraPrice)
+                    .sum();
+
+            long unitPrice = menu.getPrice().longValue() + optionExtraPrice;
+
             OrderItem orderItem = OrderItem.builder()
                     .menuId(itemDto.getMenuId())
                     .quantity(itemDto.getQuantity())
                     .unitPrice(unitPrice)
                     .build();
+            for (OptionItem optionItem : optionItems) {
+                OrderItemOption orderItemOption = OrderItemOption.builder()
+                        .optionId(optionItem.getOption().getId())
+                        .optionName(optionItem.getOption().getName())
+                        .optionItemId(optionItem.getId())
+                        .optionItemName(optionItem.getName())
+                        .extraPrice(optionItem.getExtraPrice())
+                        .build();
+
+                orderItem.addOption(orderItemOption);
+            }
             orderItems.add(orderItem);
             totalPrice += unitPrice * itemDto.getQuantity();
         }
@@ -152,15 +188,61 @@ public class OrderService {
                 .orElseThrow(OrderNotFoundException::new);
     }
 
+    private List<OptionItem> getOptionItems(List<UUID> optionItemIds) {
+        if (optionItemIds == null || optionItemIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<OptionItem> optionItems = optionItemRepository.findByIdInAndDeletedAtIsNull(optionItemIds);
+
+        if (optionItems.size() != optionItemIds.size()) {
+            throw new BusinessException(ErrorCode.OPTION_ITEM_NOT_FOUND);
+        }
+
+        Map<UUID, OptionItem> optionItemMap = optionItems.stream()
+                .collect(Collectors.toMap(OptionItem::getId, Function.identity()));
+
+        return optionItemIds.stream()
+                .map(optionItemMap::get)
+                .toList();
+    }
+
+    private void validateMenuBelongsToStore(Menu menu, UUID storeId) {
+        if (!menu.getStore().getId().equals(storeId)) {
+            throw new BusinessException(ErrorCode.MENU_NOT_FOUND_ON_READ);
+        }
+    }
+
+    private void validateOptionItemsBelongToMenu(List<OptionItem> optionItems, UUID menuId) {
+        boolean hasInvalidOptionItem = optionItems.stream()
+                .anyMatch(optionItem -> !optionItem.getOption().getMenu().getId().equals(menuId));
+
+        if (hasInvalidOptionItem) {
+            throw new BusinessException(ErrorCode.OPTION_ITEM_NOT_FOUND);
+        }
+    }
+
+    private void validateSingleOptionSelection(List<OptionItem> optionItems) {
+        Map<UUID, Long> selectedCountByOptionGroup = optionItems.stream()
+                .filter(optionItem -> optionItem.getOption().getType() == OptionType.SINGLE)
+                .collect(Collectors.groupingBy(
+                        optionItem -> optionItem.getOption().getId(),
+                        Collectors.counting()
+                ));
+
+        boolean hasDuplicatedSingleOption = selectedCountByOptionGroup.values().stream()
+                .anyMatch(count -> count > 1);
+
+        if (hasDuplicatedSingleOption) {
+            throw new BusinessException(ErrorCode.OPTION_ITEM_VALIDATION_ERROR);
+        }
+    }
+
     private int validatePageSize(int size) {
         if (size == 10 || size == 30 || size == 50) {
             return size;
         }
         return 10;
-    }
-
-    private long getActualMenuPrice(UUID menuId) {
-        return 15000L;
     }
 
     private List<UUID> getOwnerStoreIds(String userId) {

--- a/src/test/java/com/sparta/delivhub/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/menu/service/MenuServiceTest.java
@@ -121,7 +121,7 @@ class MenuServiceTest {
     void getMenu() {
         // given
         when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(menu));
-        when(optionRepository.findByMenuIdAndDeletedAtIsNull(menuId)).thenReturn(List.of());
+        when(optionRepository.findAllByMenuIdWithItems(menuId)).thenReturn(List.of()); // 수정
 
         // when
         ResponseMenuDto response = menuService.getMenu(menuId);
@@ -136,7 +136,7 @@ class MenuServiceTest {
         // given
         UpdateMenuDto request = new UpdateMenuDto();
         when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(menu));
-        when(optionRepository.findByMenuIdAndDeletedAtIsNull(menuId)).thenReturn(List.of());
+        when(optionRepository.findAllByMenuIdWithItems(menuId)).thenReturn(List.of());
 
         // when
         ResponseMenuDto response = menuService.updateMenu(menuId, request, null);

--- a/src/test/java/com/sparta/delivhub/domain/option/service/OptionServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/option/service/OptionServiceTest.java
@@ -6,6 +6,7 @@ import com.sparta.delivhub.domain.option.dto.CreateOptionDto;
 import com.sparta.delivhub.domain.option.dto.ResponseOptionDto;
 import com.sparta.delivhub.domain.option.dto.UpdateOptionDto;
 import com.sparta.delivhub.domain.option.entity.Option;
+import com.sparta.delivhub.domain.option.entity.OptionType;
 import com.sparta.delivhub.domain.option.repository.OptionRepository;
 import com.sparta.delivhub.domain.store.entity.Store;
 import com.sparta.delivhub.domain.user.entity.User;
@@ -19,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -64,7 +66,7 @@ class OptionServiceTest {
         option = mock(Option.class);
         lenient().when(option.getId()).thenReturn(optionId);
         lenient().when(option.getName()).thenReturn("소스 추가");
-        lenient().when(option.getExtraPrice()).thenReturn(500L);
+        lenient().when(option.getType()).thenReturn(OptionType.SINGLE);
         lenient().when(option.getMenu()).thenReturn(menu);
 
         User mockUser = mock(User.class);
@@ -76,7 +78,9 @@ class OptionServiceTest {
     @DisplayName("옵션 등록 성공")
     void createOption() {
         // given
-        CreateOptionDto request = new CreateOptionDto("소스 추가", 500L);
+        List<CreateOptionDto.Item> items = List.of(new CreateOptionDto.Item("소스", 500L));
+        CreateOptionDto request = new CreateOptionDto("소스 추가", OptionType.SINGLE, items);
+
         when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(menu));
         when(optionRepository.save(any(Option.class))).thenReturn(option);
 
@@ -93,7 +97,7 @@ class OptionServiceTest {
     void getOptions() {
         // given
         when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(menu));
-        when(optionRepository.findByMenuIdAndDeletedAtIsNull(menuId)).thenReturn(List.of(option));
+        when(optionRepository.findAllByMenuIdWithItems(menuId)).thenReturn(List.of(option));
 
         // when
         List<ResponseOptionDto> response = optionService.getOptions(menuId);
@@ -106,16 +110,18 @@ class OptionServiceTest {
     @DisplayName("옵션 수정 성공")
     void updateOption() {
         // given
-        UpdateOptionDto request = new UpdateOptionDto("수정된 옵션명", 1000L);
+        List<UpdateOptionDto.Item> items = List.of(new UpdateOptionDto.Item(null, "수정된 아이템", 1000L));
+        UpdateOptionDto request = new UpdateOptionDto("수정된 옵션명", OptionType.MULTIPLE, items);
+
         when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(menu));
-        when(optionRepository.findByIdAndDeletedAtIsNull(optionId)).thenReturn(Optional.of(option));
+        when(optionRepository.findByIdAndMenuIdAndDeletedAtIsNull(optionId, menuId)).thenReturn(Optional.of(option));
 
         // when
         ResponseOptionDto response = optionService.updateOption(menuId, optionId, request, null);
 
         // then
         assertThat(response).isNotNull();
-        verify(option, times(1)).update(request.getName(), request.getExtraPrice());
+        verify(option, times(1)).update(request.getName(), request.getType());
     }
 
     @Test
@@ -123,7 +129,8 @@ class OptionServiceTest {
     void deleteOption() {
         // given
         when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(menu));
-        when(optionRepository.findByIdAndDeletedAtIsNull(optionId)).thenReturn(Optional.of(option));
+        when(optionRepository.findByIdAndMenuIdWithItems(optionId, menuId)).thenReturn(Optional.of(option));
+        when(option.getOptionItems()).thenReturn(new ArrayList<>());
 
         // when
         optionService.deleteOption(menuId, optionId, null);

--- a/src/test/java/com/sparta/delivhub/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/order/service/OrderServiceTest.java
@@ -1,5 +1,8 @@
 package com.sparta.delivhub.domain.order.service;
 
+import com.sparta.delivhub.domain.menu.entity.Menu;
+import com.sparta.delivhub.domain.menu.repository.MenuRepository;
+import com.sparta.delivhub.domain.option.repository.OptionItemRepository;
 import com.sparta.delivhub.domain.order.service.dto.OrderRequestDto;
 import com.sparta.delivhub.domain.order.service.dto.OrderResponseDto;
 import com.sparta.delivhub.domain.order.service.entity.Order;
@@ -43,31 +46,70 @@ class OrderServiceTest {
     @Mock
     private PaymentRepository paymentRepository;
 
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Mock
+    private OptionItemRepository optionItemRepository;
+
     @Test
     @DisplayName("주문 생성 테스트 - 성공")
     void createOrder_Success() {
         // given
         String userId = "user01";
+        UUID menuId = UUID.randomUUID();
+        UUID storeId = UUID.randomUUID();
+        UUID optionItemId = UUID.randomUUID();
+        UUID optionId = UUID.randomUUID();
+
         OrderRequestDto requestDto = OrderRequestDto.builder()
-                .storeId(UUID.randomUUID())
+                .storeId(storeId)
                 .addressId(UUID.randomUUID())
                 .request("많이 주세요")
                 .orderType(OrderType.ONLINE)
                 .items(List.of(
                         OrderRequestDto.OrderItemRequestDto.builder()
-                                .menuId(UUID.randomUUID())
+                                .menuId(menuId)
                                 .quantity(2)
+                                .optionItemIds(List.of(optionItemId))
                                 .build()
                 ))
                 .build();
 
+        // Store mock
+        com.sparta.delivhub.domain.store.entity.Store mockStore = mock(com.sparta.delivhub.domain.store.entity.Store.class);
+        when(mockStore.getId()).thenReturn(storeId);
+
+        // Menu mock
+        Menu mockMenu = mock(Menu.class);
+        when(mockMenu.getStore()).thenReturn(mockStore);
+        when(mockMenu.getPrice()).thenReturn(15000);
+        when(mockMenu.getId()).thenReturn(menuId);
+
+        // Option mock (SINGLE 타입)
+        com.sparta.delivhub.domain.option.entity.Option mockOption = mock(com.sparta.delivhub.domain.option.entity.Option.class);
+        when(mockOption.getId()).thenReturn(optionId);
+        when(mockOption.getName()).thenReturn("맵기 선택");
+        when(mockOption.getType()).thenReturn(com.sparta.delivhub.domain.option.entity.OptionType.SINGLE);
+        when(mockOption.getMenu()).thenReturn(mockMenu);
+
+        // OptionItem mock
+        com.sparta.delivhub.domain.option.entity.OptionItem mockOptionItem = mock(com.sparta.delivhub.domain.option.entity.OptionItem.class);
+        when(mockOptionItem.getId()).thenReturn(optionItemId);
+        when(mockOptionItem.getName()).thenReturn("보통");
+        when(mockOptionItem.getExtraPrice()).thenReturn(0L);
+        when(mockOptionItem.getOption()).thenReturn(mockOption);
+
+        when(menuRepository.findByIdAndDeletedAtIsNull(menuId)).thenReturn(Optional.of(mockMenu));
+        when(optionItemRepository.findByIdInAndDeletedAtIsNull(List.of(optionItemId))).thenReturn(List.of(mockOptionItem));
+
         Order order = Order.builder()
                 .userId(userId)
-                .storeId(requestDto.getStoreId())
+                .storeId(storeId)
                 .addressId(requestDto.getAddressId())
                 .request(requestDto.getRequest())
                 .orderType(requestDto.getOrderType())
-                .totalPrice(30000L) // 15000 * 2 (현재 하드코딩된 가격 기준)
+                .totalPrice(30000L)
                 .build();
         ReflectionTestUtils.setField(order, "id", UUID.randomUUID());
 
@@ -79,7 +121,6 @@ class OrderServiceTest {
         // then
         assertNotNull(response);
         assertEquals(userId, order.getUserId());
-        assertEquals(30000L, order.getTotalPrice());
         verify(orderRepository).save(any(Order.class));
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 진행 중이면 `Refs #123`, 완전 해결이면 `Closes #123` (완전히 끝났을 때만)
- Refs/Closes: #71 

---

## 📌 작업 내용 요약
- [x]  옵션 구조를 Option 그룹과 OptionItem 선택지 구조로 분리
- [x] 메뉴 생성/조회 시 옵션 그룹과 옵션 아이템을 함께 처리하도록 수정
- [x] 주문 생성 시 선택한 옵션 아이템을 반영하여 주문 금액 계산 및 주문 내역에 저장

---

## 🧱 변경 범위 (Scope)
### Backend
- [x] API 추가/수정
- [x] Validation/예외처리
- [ ] 인증/인가
- [x] DB 스키마/쿼리
- [x] 기타: 주문 옵션 스냅샷 저장 구조 추가

---

## 🧪 테스트 내역
### Backend
- [x] 로컬에서 애플리케이션 실행 확인
- [ ] 단위 테스트 통과
- [x] API 수동 테스트 (Postman / Swagger 등)


### 테스트 상세(필수)
- 메뉴 생성 시 옵션 그룹과 옵션 아이템이 함께 생성되는지 확인
- 메뉴 조회 시 옵션 그룹, 선택 방식, 옵션 아이템 목록이 정상 반환되는지 확인
- 주문 생성 시 optionItemIds 전달 시 선택 옵션이 주문 항목에 반영되는지 확인
- 주문 생성 시 메뉴 가격과 옵션 추가금이 합산되어 unitPrice, totalPrice 계산되는지 확인
- 주문 조회 시 선택한 옵션의 그룹명, 아이템명, 추가금액이 정상 반환되는지 확인
- SINGLE 타입 옵션 그룹에서 중복 선택 시 예외 발생 확인
