### PR TITLE
refactor: [LSG] Redis를 활용한 JWT 무효화 및 Refresh Token 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/delivhub/config/RedisConfig.java
+++ b/src/main/java/com/sparta/delivhub/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.sparta.delivhub.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/sparta/delivhub/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivhub/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll()
+                        .requestMatchers("/api/v1/auth/reissue").permitAll()
 
                         //User
                         .requestMatchers(HttpMethod.GET, "/api/v1/users").hasAnyRole("MANAGER", "MASTER")

--- a/src/main/java/com/sparta/delivhub/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/delivhub/domain/auth/controller/AuthController.java
@@ -1,19 +1,15 @@
 package com.sparta.delivhub.domain.auth.controller;
 
 import com.sparta.delivhub.common.dto.ApiResponse;
-import com.sparta.delivhub.domain.auth.dto.LoginRequest;
-import com.sparta.delivhub.domain.auth.dto.LoginResponse;
-import com.sparta.delivhub.domain.auth.dto.SignupRequest;
-import com.sparta.delivhub.domain.auth.dto.SignupResponse;
+import com.sparta.delivhub.domain.auth.dto.*;
 import com.sparta.delivhub.domain.auth.service.AuthService;
+import com.sparta.delivhub.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -41,4 +37,27 @@ public class AuthController {
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(response));
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<?>> logout(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        authService.logout(userDetails.getUsername());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success());
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<?>> reissue(
+            @RequestHeader("Authorization") String bearerToken
+    ) {
+        String refreshToken = bearerToken.substring(7);
+        ReissueResponse response = authService.reissue(refreshToken);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(response));
+    }
+
 }

--- a/src/main/java/com/sparta/delivhub/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/delivhub/domain/auth/controller/AuthController.java
@@ -1,8 +1,13 @@
 package com.sparta.delivhub.domain.auth.controller;
 
 import com.sparta.delivhub.common.dto.ApiResponse;
-import com.sparta.delivhub.domain.auth.dto.*;
+import com.sparta.delivhub.domain.auth.dto.LoginRequest;
+import com.sparta.delivhub.domain.auth.dto.LoginResponse;
+import com.sparta.delivhub.domain.auth.dto.ReissueResponse;
+import com.sparta.delivhub.domain.auth.dto.SignupRequest;
+import com.sparta.delivhub.domain.auth.dto.SignupResponse;
 import com.sparta.delivhub.domain.auth.service.AuthService;
+import com.sparta.delivhub.security.JwtTokenProvider;
 import com.sparta.delivhub.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(
@@ -52,7 +58,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<?>> reissue(
             @RequestHeader("Authorization") String bearerToken
     ) {
-        String refreshToken = bearerToken.substring(7);
+        String refreshToken = jwtTokenProvider.extractBearerToken(bearerToken);
         ReissueResponse response = authService.reissue(refreshToken);
 
         return ResponseEntity

--- a/src/main/java/com/sparta/delivhub/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/sparta/delivhub/domain/auth/dto/LoginResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public class LoginResponse {
 
     private String accessToken;
+    private String refreshToken;
     private String username;
     private UserRole role;
 }

--- a/src/main/java/com/sparta/delivhub/domain/auth/dto/ReissueResponse.java
+++ b/src/main/java/com/sparta/delivhub/domain/auth/dto/ReissueResponse.java
@@ -1,0 +1,11 @@
+package com.sparta.delivhub.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReissueResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/sparta/delivhub/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/delivhub/domain/auth/service/AuthService.java
@@ -2,7 +2,11 @@ package com.sparta.delivhub.domain.auth.service;
 
 import com.sparta.delivhub.common.dto.BusinessException;
 import com.sparta.delivhub.common.dto.ErrorCode;
-import com.sparta.delivhub.domain.auth.dto.*;
+import com.sparta.delivhub.domain.auth.dto.LoginRequest;
+import com.sparta.delivhub.domain.auth.dto.LoginResponse;
+import com.sparta.delivhub.domain.auth.dto.ReissueResponse;
+import com.sparta.delivhub.domain.auth.dto.SignupRequest;
+import com.sparta.delivhub.domain.auth.dto.SignupResponse;
 import com.sparta.delivhub.domain.user.entity.User;
 import com.sparta.delivhub.domain.user.repository.UserRepository;
 import com.sparta.delivhub.security.JwtTokenProvider;

--- a/src/main/java/com/sparta/delivhub/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/delivhub/domain/auth/service/AuthService.java
@@ -2,13 +2,12 @@ package com.sparta.delivhub.domain.auth.service;
 
 import com.sparta.delivhub.common.dto.BusinessException;
 import com.sparta.delivhub.common.dto.ErrorCode;
-import com.sparta.delivhub.domain.auth.dto.LoginRequest;
-import com.sparta.delivhub.domain.auth.dto.LoginResponse;
-import com.sparta.delivhub.domain.auth.dto.SignupRequest;
-import com.sparta.delivhub.domain.auth.dto.SignupResponse;
+import com.sparta.delivhub.domain.auth.dto.*;
 import com.sparta.delivhub.domain.user.entity.User;
 import com.sparta.delivhub.domain.user.repository.UserRepository;
 import com.sparta.delivhub.security.JwtTokenProvider;
+import com.sparta.delivhub.security.TokenService;
+import com.sparta.delivhub.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,12 +17,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -51,6 +50,7 @@ public class AuthService {
         return SignupResponse.from(saved);
     }
 
+    @Transactional
     public LoginResponse login(LoginRequest request) {
 
         // 아이디 조회
@@ -67,15 +67,59 @@ public class AuthService {
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
 
-        String token = jwtTokenProvider.createAccessToken(
+        // accessToken 생성
+        String accessToken = jwtTokenProvider.createAccessToken(
                 user.getUsername(),
                 List.of(() -> "ROLE_" + user.getUserRole().name())
         );
 
+        // refreshToken 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getUsername());
+
+        // refreshToken 기한 설정
+        long refreshExpiration = jwtTokenProvider.getRemainingExpiration(refreshToken);
+
+        // refreshToken 저장
+        tokenService.saveRefreshToken(user.getUsername(), refreshToken, refreshExpiration);
+
         return LoginResponse.builder()
-                .accessToken(token)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .username(user.getUsername())
                 .role(user.getUserRole())
                 .build();
     }
+
+    @Transactional
+    public void logout(String username) {
+        tokenService.deleteRefreshToken(username);
+    }
+
+    @Transactional
+    public ReissueResponse reissue(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String username = jwtTokenProvider.getUsername(refreshToken);
+
+        // Redis 에 저장된 RT와 비교 (중복 로그인 시 이전 RT 무효화)
+        String storedRT = tokenService.getRefreshToken(username);
+        if (storedRT == null || !storedRT.equals(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        User user = userRepository.findByUsernameAndDeletedAtIsNull(username)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 새 AT 발급
+        UserDetailsImpl userDetails = new UserDetailsImpl(user);
+        String newAccessToken = jwtTokenProvider.createAccessToken(
+                username, userDetails.getAuthorities());
+
+        return ReissueResponse.builder()
+                .accessToken(newAccessToken)
+                .build();
+    }
+
 }

--- a/src/main/java/com/sparta/delivhub/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivhub/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.sparta.delivhub.domain.user.dto.UserResponse;
 import com.sparta.delivhub.domain.user.entity.User;
 import com.sparta.delivhub.domain.user.entity.UserRole;
 import com.sparta.delivhub.domain.user.repository.UserRepository;
+import com.sparta.delivhub.security.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,6 +27,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TokenService tokenService;
 
     public PageResponse<UserResponse> getUsers(
             String keyword,
@@ -124,15 +126,13 @@ public class UserService {
         }
 
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
-
-        // todo : 토큰 무효화
+        tokenService.deleteRefreshToken(username);
     }
 
     @Transactional
     public void deleteUser(String username, String deletedBy) {
         User user = findUserByUsername(username);
         user.softDelete(deletedBy);
-
-        // todo : 토큰 무효화
+        tokenService.deleteRefreshToken(username);
     }
 }

--- a/src/main/java/com/sparta/delivhub/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivhub/security/JwtAuthenticationFilter.java
@@ -69,5 +69,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 
+    // reissue 엔드포인트는 필터 스킵
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getServletPath().equals("/api/v1/auth/reissue");
+    }
 
 }

--- a/src/main/java/com/sparta/delivhub/security/JwtTokenProvider.java
+++ b/src/main/java/com/sparta/delivhub/security/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.sparta.delivhub.security;
 
+import com.sparta.delivhub.common.dto.BusinessException;
+import com.sparta.delivhub.common.dto.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.Jwts;
@@ -104,6 +106,14 @@ public class JwtTokenProvider {
     public long getRemainingExpiration(String token) {
         Date expiration = parseClaims(token).getExpiration();
         return expiration.getTime() - System.currentTimeMillis();
+    }
+
+    // 헤더 형식 검증
+    public String extractBearerToken(String bearerToken) {
+        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+        return bearerToken.substring(7);
     }
 
 }

--- a/src/main/java/com/sparta/delivhub/security/JwtTokenProvider.java
+++ b/src/main/java/com/sparta/delivhub/security/JwtTokenProvider.java
@@ -100,4 +100,10 @@ public class JwtTokenProvider {
         }
     }
 
+    // Token 남은 만료 시간 - Redis RT 저장 TTL 설정용
+    public long getRemainingExpiration(String token) {
+        Date expiration = parseClaims(token).getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
 }

--- a/src/main/java/com/sparta/delivhub/security/TokenService.java
+++ b/src/main/java/com/sparta/delivhub/security/TokenService.java
@@ -1,0 +1,30 @@
+package com.sparta.delivhub.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // refreshToken
+    private static final String RT_PREFIX = "RT:";
+
+    public void saveRefreshToken(String username, String refreshToken, long duration) {
+        redisTemplate.opsForValue()
+                .set(RT_PREFIX + username, refreshToken, duration, TimeUnit.MILLISECONDS);
+    }
+
+    public String getRefreshToken(String username) {
+        return redisTemplate.opsForValue().get(RT_PREFIX + username);
+    }
+
+    public void deleteRefreshToken(String username) {
+        redisTemplate.delete(RT_PREFIX + username);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-validity-ms: 3600000
+  access-token-validity-ms: 1800000
   refresh-token-validity-ms: 604800000
 
 gemini:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
   profiles:
     active: dev
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/test/java/com/sparta/delivhub/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/auth/service/AuthServiceTest.java
@@ -2,14 +2,13 @@ package com.sparta.delivhub.domain.auth.service;
 
 import com.sparta.delivhub.common.dto.BusinessException;
 import com.sparta.delivhub.common.dto.ErrorCode;
-import com.sparta.delivhub.domain.auth.dto.LoginRequest;
-import com.sparta.delivhub.domain.auth.dto.LoginResponse;
-import com.sparta.delivhub.domain.auth.dto.SignupRequest;
-import com.sparta.delivhub.domain.auth.dto.SignupResponse;
+import com.sparta.delivhub.domain.auth.dto.*;
 import com.sparta.delivhub.domain.user.entity.User;
 import com.sparta.delivhub.domain.user.entity.UserRole;
 import com.sparta.delivhub.domain.user.repository.UserRepository;
 import com.sparta.delivhub.security.JwtTokenProvider;
+import com.sparta.delivhub.security.TokenService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,8 +37,22 @@ class AuthServiceTest {
     @Mock
     private JwtTokenProvider jwtTokenProvider;
 
+    @Mock
+    private TokenService tokenService;
+
     @InjectMocks
     private AuthService authService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .username("user01")
+                .password("encodedPassword")
+                .userRole(UserRole.CUSTOMER)
+                .build();
+    }
 
     @Test
     @DisplayName("회원가입_성공")
@@ -115,12 +128,6 @@ class AuthServiceTest {
     @DisplayName("로그인_성공")
     void loginSuccess() {
         //given
-        User user = User.builder()
-                .username("user01")
-                .password("encodedPassword")
-                .userRole(UserRole.CUSTOMER)
-                .build();
-
         LoginRequest request = LoginRequest.builder()
                 .username("user01")
                 .password("Password1!")
@@ -129,14 +136,18 @@ class AuthServiceTest {
         given(userRepository.findByUsername("user01")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Password1!", user.getPassword())).willReturn(true);
         given(jwtTokenProvider.createAccessToken(eq("user01"), anyList())).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken("user01")).willReturn("refresh-token");
+        given(jwtTokenProvider.getRemainingExpiration("refresh-token")).willReturn(604800000L);
 
         //when
         LoginResponse response = authService.login(request);
 
         //then
         assertThat(response.getAccessToken()).isEqualTo("access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
         assertThat(response.getUsername()).isEqualTo("user01");
         assertThat(response.getRole()).isEqualTo(UserRole.CUSTOMER);
+        verify(tokenService).saveRefreshToken(eq("user01"), eq("refresh-token"), anyLong());
     }
 
     @Test
@@ -161,12 +172,6 @@ class AuthServiceTest {
     @DisplayName("로그인_실패_탈퇴_계정")
     void login_fail_deactivatedAccount() {
         //given
-        User user = User.builder()
-                .username("user01")
-                .password("encodedPassword")
-                .userRole(UserRole.CUSTOMER)
-                .build();
-
         user.softDelete("admin");
 
         LoginRequest request = LoginRequest.builder()
@@ -187,12 +192,6 @@ class AuthServiceTest {
     @DisplayName("로그인_실패_비밀번호_불일치")
     void login_fail_wrongPassword() {
         //given
-        User user = User.builder()
-                .username("user01")
-                .password("encodedPassword")
-                .userRole(UserRole.CUSTOMER)
-                .build();
-
         LoginRequest request = LoginRequest.builder()
                 .username("user01")
                 .password("Password1!")
@@ -205,5 +204,60 @@ class AuthServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_CREDENTIALS);
+    }
+
+    @Test
+    @DisplayName("로그아웃_성공")
+    void logout_success() {
+        // when
+        authService.logout("user01");
+
+        // then
+        verify(tokenService).deleteRefreshToken("user01");
+    }
+
+    @Test
+    @DisplayName("AT_재발급_성공")
+    void reissue_success() {
+        // given
+        given(jwtTokenProvider.validateToken("refresh-token")).willReturn(true);
+        given(jwtTokenProvider.getUsername("refresh-token")).willReturn("user01");
+        given(tokenService.getRefreshToken("user01")).willReturn("refresh-token");
+        given(userRepository.findByUsernameAndDeletedAtIsNull("user01")).willReturn(Optional.of(user));
+        given(jwtTokenProvider.createAccessToken(eq("user01"), anyCollection())).willReturn("new-access-token");
+
+        // when
+        ReissueResponse response = authService.reissue("refresh-token");
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+    }
+
+    @Test
+    @DisplayName("AT_재발급_실패_유효하지않은_RT")
+    void reissue_fail_invalidToken() {
+        // given
+        given(jwtTokenProvider.validateToken("invalid-token")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissue("invalid-token"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("AT_재발급_실패_RT_없음_로그아웃_상태_RT_삭제")
+    void reissue_fail_tokenNotFound() {
+        // given
+        given(jwtTokenProvider.validateToken("refresh-token")).willReturn(true);
+        given(jwtTokenProvider.getUsername("refresh-token")).willReturn("user01");
+        given(tokenService.getRefreshToken("user01")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissue("refresh-token"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_TOKEN);
     }
 }

--- a/src/test/java/com/sparta/delivhub/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivhub/domain/user/service/UserServiceTest.java
@@ -10,6 +10,7 @@ import com.sparta.delivhub.domain.user.dto.UserResponse;
 import com.sparta.delivhub.domain.user.entity.User;
 import com.sparta.delivhub.domain.user.entity.UserRole;
 import com.sparta.delivhub.domain.user.repository.UserRepository;
+import com.sparta.delivhub.security.TokenService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,9 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private TokenService tokenService;
 
     @InjectMocks
     private UserService userService;
@@ -269,6 +273,7 @@ class UserServiceTest {
 
         // then
         verify(passwordEncoder).encode("NewPassword1!");
+        verify(tokenService).deleteRefreshToken("user01");
     }
 
     @Test
@@ -316,8 +321,9 @@ class UserServiceTest {
         userService.deleteUser("user01", "admin");
 
         // then
-        verify(userRepository).findByUsernameAndDeletedAtIsNull("user01");
         assertThat(user.getDeletedAt()).isNotNull();
+        verify(userRepository).findByUsernameAndDeletedAtIsNull("user01");
+        verify(tokenService).deleteRefreshToken("user01");
     }
 
     @Test


### PR DESCRIPTION
## 🔗 관련 이슈
> 진행 중이면 `Refs #123`, 완전 해결이면 `Closes #123` (완전히 끝났을 때만)
- Refs/Closes: #63 

---

## 📌 작업 내용 요약
- [x] Redis 기반 RefreshToken 저장/삭제로 로그아웃 구현
- [x] AccessToken + RefreshToken 이중 토큰 전략 적용 (AT 30분 / RT 7일)
- [x] `/auth/reissue` 엔드포인트 추가 및 필터 스킵 처리

---

## 🧱 변경 범위 (Scope)
### Backend
- [x] API 추가/수정
- [ ] Validation/예외처리
- [x] 인증/인가
- [ ] DB 스키마/쿼리
- [x] 기타: RedisConfig, TokenService 신규 추가 / application.yml Redis 설정 추가

---

## 🧪 테스트 내역
### Backend
- [x] 로컬에서 애플리케이션 실행 확인
- [x] 단위 테스트 통과
- [ ] API 수동 테스트 (Postman / Swagger 등)


### 테스트 상세(필수)
> 테스트한 API/페이지/케이스를 간단히 적어주세요.
- 로그인 → AT + RT 발급, Redis에 RT 저장 확인
- `/auth/reissue` → RT 유효 시 새 AT 발급 성공
- `/auth/reissue` → 로그아웃 후 RT 삭제된 상태에서 401 반환 확인
- `/auth/logout` → Redis에서 RT 삭제, 이후 reissue 차단 확인
- 비밀번호 변경 / 회원 탈퇴 → RT 삭제로 재발급 차단 확인
- AuthServiceTest: login, logout, reissue 성공/실패 단위 테스트 통과

---

## 🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
- before:
- after:

---

## ⚠️ 영향도 / 리스크 / 롤백
> 리뷰어가 “머지해도 되는지” 판단하기 위한 섹션입니다.
- 리스크: Redis 서버 미실행 시 로그인 자체 불가 (`RedisConnectionFailureException`) — 로컬 실행 시 Docker로 Redis 띄워야 함 등)

---

## ✅ 리뷰어 체크 포인트 (선택)
> 리뷰어가 집중해서 봐줬으면 하는 부분이 있으면 적어주세요.
- 예) 트랜잭션 범위, 권한 체크, N+1, 상태관리 로직 등
